### PR TITLE
Added role-based authorization for TeacherDashboard

### DIFF
--- a/backend/api/Controllers/AccountController.cs
+++ b/backend/api/Controllers/AccountController.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Identity;
+using api.Data;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AccountController : ControllerBase
+{
+    [Authorize]
+    [HttpGet("me")]
+    public IActionResult Me()
+    {
+        var user = HttpContext.User;
+
+        var name = user.Identity?.Name;
+
+        var roles = user.Claims
+            .Where(c => c.Type == ClaimTypes.Role)
+            .Select(c => c.Value)
+            .ToList();
+
+        return Ok(new
+        {
+            Name = name,
+            Roles = roles
+        });
+    }
+
+    [HttpPost("login-test")]
+    public async Task<IActionResult> LoginTest([FromServices] SignInManager<ApplicationUser> signInManager)
+    {
+        var user = await signInManager.UserManager.FindByNameAsync("teacher");
+
+        if (user == null)
+        {
+            return NotFound("User not found");
+        }
+
+        await signInManager.SignInAsync(user, isPersistent: true);
+
+            return Ok();
+    }
+}

--- a/backend/api/Program.cs
+++ b/backend/api/Program.cs
@@ -18,6 +18,7 @@ builder.Services.AddCors(options =>
     {
         policy.AllowAnyHeader()
               .AllowAnyMethod()
+              .AllowCredentials()
               .WithOrigins("http://localhost:5001"); // frontend URL
     });
 });

--- a/blazor/blazor/App.razor
+++ b/blazor/blazor/App.razor
@@ -1,6 +1,19 @@
-﻿<Router AppAssembly="@typeof(App).Assembly" NotFoundPage="typeof(Pages.NotFound)">
-    <Found Context="routeData">
-        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)"/>
-        <FocusOnNavigate RouteData="@routeData" Selector="h1" />
-    </Found>
-</Router>
+﻿<CascadingAuthenticationState>
+    <Router AppAssembly="@typeof(App).Assembly" NotFoundPage="typeof(Pages.NotFound)">
+        <Found Context="routeData">
+            <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
+                
+                <NotAuthorized>
+                    <h3>Du har ikke adgang</h3>
+                </NotAuthorized>
+
+                <Authorizing>
+                    <h3>Tjekker login...</h3>
+                </Authorizing>
+
+            </AuthorizeRouteView>
+
+            <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+        </Found>
+    </Router>
+</CascadingAuthenticationState>

--- a/blazor/blazor/Pages/TeacherDashboard.razor
+++ b/blazor/blazor/Pages/TeacherDashboard.razor
@@ -1,4 +1,5 @@
 @page "/teacher-dashboard"
+@attribute [Authorize(Roles = "Teacher")]
 
 <h3>Lærer Dashboard</h3>
 

--- a/blazor/blazor/Program.cs
+++ b/blazor/blazor/Program.cs
@@ -1,11 +1,18 @@
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using blazor;
+using Microsoft.AspNetCore.Components.Authorization;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
-builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+builder.Services.AddAuthorizationCore();
+builder.Services.AddScoped<AuthenticationStateProvider, ApiAuthStateProvider>();
+
+builder.Services.AddScoped(sp => new HttpClient
+{
+    BaseAddress = new Uri("https://localhost:5000") // backend URL
+});
 
 await builder.Build().RunAsync();

--- a/blazor/blazor/Services/ApiAuthStateProvider.cs
+++ b/blazor/blazor/Services/ApiAuthStateProvider.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Components.Authorization;
+using System.Security.Claims;
+using System.Net.Http.Json;
+
+public class ApiAuthStateProvider : AuthenticationStateProvider
+{
+    private readonly HttpClient _http;
+
+    public ApiAuthStateProvider(HttpClient http)
+    {
+        _http = http;
+    }
+
+    public override async Task<AuthenticationState> GetAuthenticationStateAsync()
+    {
+        try
+        {
+            var userInfo = await _http.GetFromJsonAsync<UserInfo>("api/account/me");
+
+            if (userInfo == null)
+                return new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity()));
+
+            var claims = new List<Claim>
+            {
+                new Claim(ClaimTypes.Name, userInfo.Name)
+            };
+
+            claims.AddRange(userInfo.Roles.Select(role => new Claim(ClaimTypes.Role, role)));
+
+            var identity = new ClaimsIdentity(claims, "api");
+            var user = new ClaimsPrincipal(identity);
+
+            return new AuthenticationState(user);
+        }
+        catch
+        {
+            return new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity()));
+        }
+    }
+}

--- a/blazor/blazor/_Imports.razor
+++ b/blazor/blazor/_Imports.razor
@@ -5,6 +5,8 @@
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.AspNetCore.Components.WebAssembly.Http
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.JSInterop
 @using blazor
 @using blazor.Layout

--- a/blazor/blazor/blazor.csproj
+++ b/blazor/blazor/blazor.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.3" PrivateAssets="all" />
   </ItemGroup>

--- a/blazor/blazor/models/UserInfo.cs
+++ b/blazor/blazor/models/UserInfo.cs
@@ -1,0 +1,5 @@
+public class UserInfo
+{
+    public string Name { get; set; } = string.Empty;
+    public List<string> Roles { get; set; } = new();
+}


### PR DESCRIPTION
- Implemented AuthenticationStateProvider in Blazor frontend
- Integrated API-based user authentication via /api/account/me
- Added role-based access control using [Authorize(Roles = "Teacher")]
- Restricted TeacherDashboard to authenticated users with Teacher role
- Added temporary login-test endpoint for development/testing