### PR TITLE
Create AssignmentSheet API

### DIFF
--- a/backend/api/Controllers/AssignmentController.cs
+++ b/backend/api/Controllers/AssignmentController.cs
@@ -64,6 +64,18 @@ namespace api.Controllers
             return Ok(result);
         }
 
+        [HttpGet("with-id")]
+        public async Task<ActionResult<List<AssignmentWithIdDTO>>> GetAssignmentsWithId(){
+            var assignments = await _assignmentservice.GetAll();
+            return Ok(assignments.Select(a => new AssignmentWithIdDTO{
+                Id = a.Id,
+                Subject = a.Subject,
+                Topic = a.Topic,
+                Number = a.Number
+            }).ToList());
+        }
+
+
         [HttpPost]
         public async Task<ActionResult<Assignment>> CreateAssignment([FromForm] Assignment newAssignment, [FromForm] IFormFileCollection images){
             if (newAssignment == null)

--- a/backend/api/Controllers/AssignmentSheetController.cs
+++ b/backend/api/Controllers/AssignmentSheetController.cs
@@ -1,0 +1,69 @@
+using Microsoft.AspNetCore.Mvc;
+using api.Models;
+using api.DTOs;
+using api.Services;
+using QuestPDF.Fluent;
+
+namespace api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AssignmentSheetController : ControllerBase
+{
+    private readonly AssignmentService _assignmentService;
+
+    public AssignmentSheetController(AssignmentService assignmentService)
+    {
+        _assignmentService = assignmentService;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateAssignmentSheetDto dto)
+    {
+        if (dto.TaskIds == null || !dto.TaskIds.Any())
+            return BadRequest("Ingen opgaver valgt");
+
+        if (dto.Type != "prøve" && dto.Type != "lektier")
+            return BadRequest("Ugyldig type");
+
+        var allAssignments = await _assignmentService.GetAll();
+
+        var selectedTasks = allAssignments
+            .Where(a => dto.TaskIds.Contains(a.Id))
+            .ToList();
+
+        var sheet = new AssignmentSheet
+        {
+            Tasks = selectedTasks,
+            Type = dto.Type
+        };
+
+        var pdfBytes = GeneratePdf(sheet);
+
+        return File(pdfBytes, "application/pdf", "opgavesaet.pdf");
+    }
+
+    private byte[] GeneratePdf(AssignmentSheet sheet)
+    {
+        return Document.Create(container =>
+        {
+            container.Page(page =>
+            {
+                page.Margin(20);
+                page.Content().Column(col =>
+                {
+                    col.Item().Text($"Opgavesæt ({sheet.Type})").FontSize(20).Bold();
+
+                    foreach (var task in sheet.Tasks)
+                    {
+                        col.Item().Text($"{task.Subject} - {task.Topic}").Bold();
+                        col.Item().Text($"Spørgsmål {task.Number}");
+                        col.Item().Text($"Svar: {task.Answer}");
+                        col.Item().Text($"Point: {task.Points}");
+                        col.Item().PaddingBottom(10);
+                    }
+                });
+            });
+        }).GeneratePdf();
+    }
+}

--- a/backend/api/DTOs/AssignmentWithIdDTO.cs
+++ b/backend/api/DTOs/AssignmentWithIdDTO.cs
@@ -1,0 +1,7 @@
+public class AssignmentWithIdDTO
+{
+    public Guid Id { get; set; }
+    public string Subject { get; set; } = "";
+    public string Topic { get; set; } = "";
+    public int Number { get; set; } = 1;
+}

--- a/backend/api/DTOs/CreateAssignmentSheetDTO.cs
+++ b/backend/api/DTOs/CreateAssignmentSheetDTO.cs
@@ -1,0 +1,7 @@
+namespace api.DTOs;
+
+public class CreateAssignmentSheetDto
+{
+    public List<Guid> TaskIds { get; set; } = new(); // Kun ID'er er nødvendige for at oprette et AssignmentSheet
+    public string Type { get; set; } = "";
+}

--- a/backend/api/Models/AssignmentSheet.cs
+++ b/backend/api/Models/AssignmentSheet.cs
@@ -1,0 +1,9 @@
+namespace api.Models;
+
+public class AssignmentSheet
+{
+    public int Id { get; set; }
+    public List<Assignment> Tasks { get; set; } = new();
+    public string Type { get; set; } = ""; // "prøve" eller "lektier"
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/api/api.csproj
+++ b/backend/api/api.csproj
@@ -17,6 +17,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
     <PackageReference Include="MongoDB.Driver" Version="3.7.1" />
+    <PackageReference Include="QuestPDF" Version="2026.2.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/blazor/blazor/Pages/CreateAssignmentSheet.razor
+++ b/blazor/blazor/Pages/CreateAssignmentSheet.razor
@@ -1,45 +1,49 @@
 @page "/create-assignment-sheet"
+@using blazor.models
+@inject HttpClient Http
 
 <h3>Lav opgavesæt</h3>
 
 <div class="container">
 
-    <!-- VENSTRE: ALLE OPGAVER -->
+    <!-- VENSTRE: Alle opgaver -->
     <div class="box">
-        <h4>Opgaver</h4>
-
+        <h4>Alle opgaver</h4>
         <input placeholder="Filter..." @bind="FilterText" class="form-control" />
 
         @foreach (var assignment in FilteredAssignments)
         {
             <div class="item" @onclick="() => AddToSheet(assignment)">
-                @assignment.Title
+                @assignment.Subject - @assignment.Topic (Spg. @assignment.Number)
             </div>
         }
     </div>
 
-    <!-- PIL -->
-    <div class="arrow">
-        ➡
-    </div>
+    <div class="arrow">➡</div>
 
-    <!-- HØJRE: VALGTE OPGAVER -->
+    <!-- HØJRE: Valgte opgaver -->
     <div class="box">
-        <h4>Opgavesæt</h4>
+        <h4>Valgte opgaver</h4>
 
         @for (int i = 0; i < SelectedAssignments.Count; i++)
         {
             var assignment = SelectedAssignments[i];
-
-        <div class="item selected"
-            @onclick="() => RemoveFromSheet(assignment)">
-
-            <strong>@(i + 1).</strong> @assignment.Title
-
-        </div>
+            <div class="item selected" @onclick="() => RemoveFromSheet(assignment)">
+                <strong>@(i + 1).</strong> @assignment.Subject - @assignment.Topic
+            </div>
         }
 
-        <button class="btn btn-success" @onclick="SaveAssignmentSheet">
+        <div class="mt-2">
+            <label>Type:</label>
+            <select @bind="SelectedType" class="form-control">
+                <option value="">Vælg type</option>
+                <option value="prøve">Prøve</option>
+                <option value="lektier">Lektier</option>
+            </select>
+        </div>
+
+        <button class="btn btn-success mt-2" @onclick="SaveAssignmentSheet"
+                disabled="@(!SelectedAssignments.Any())">
             Gem opgavesæt
         </button>
     </div>
@@ -47,52 +51,70 @@
 </div>
 
 @code {
-
-    private List<Assignment> AllAssignments = new();
-    private List<Assignment> SelectedAssignments = new();
+    private List<AssignmentSheetItem> AllAssignments = new();
+    private List<AssignmentSheetItem> SelectedAssignments = new();
 
     private string FilterText = "";
+    private string SelectedType = "";
 
-    // Midlertidig mock data (indtil API er klar)
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
-        AllAssignments = new List<Assignment>
+        // Hent assignments fra backend. Backend endpoint skal returnere Id!
+        var allFromBackend = await Http.GetFromJsonAsync<List<AssignmentSheetItem>>("http://localhost:5000/api/assignment/with-id")
+                               ?? new List<AssignmentSheetItem>();
+
+        // Map til frontend DTO
+        AllAssignments = allFromBackend.Select(a => new AssignmentSheetItem
         {
-            new Assignment { Id = 1, Title = "Matematik - Algebra" },
-            new Assignment { Id = 2, Title = "Dansk - Analyse" },
-            new Assignment { Id = 3, Title = "Engelsk - Essay" },
-            new Assignment { Id = 4, Title = "Fysik - Energi" }
-        };
+            Id = a.Id,
+            Subject = a.Subject,
+            Topic = a.Topic,
+            Number = a.Number
+        }).ToList();
     }
 
-    private IEnumerable<Assignment> FilteredAssignments =>
+    private IEnumerable<AssignmentSheetItem> FilteredAssignments =>
         AllAssignments.Where(a =>
             string.IsNullOrWhiteSpace(FilterText) ||
-            a.Title.Contains(FilterText, StringComparison.OrdinalIgnoreCase));
+            a.Subject.Contains(FilterText, StringComparison.OrdinalIgnoreCase) ||
+            a.Topic.Contains(FilterText, StringComparison.OrdinalIgnoreCase));
 
-    private void AddToSheet(Assignment assignment)
+    private void AddToSheet(AssignmentSheetItem assignment)
     {
         if (!SelectedAssignments.Contains(assignment))
-        {
             SelectedAssignments.Add(assignment);
-        }
     }
 
-    private void RemoveFromSheet(Assignment assignment)
+    private void RemoveFromSheet(AssignmentSheetItem assignment)
     {
         SelectedAssignments.Remove(assignment);
     }
 
-    private void SaveAssignmentSheet()
+    private async Task SaveAssignmentSheet()
     {
-        // Her skal API kald komme senere
-        Console.WriteLine("Gemmer opgavesæt...");
-    }
+        if (string.IsNullOrEmpty(SelectedType))
+        {
+            Console.WriteLine("Vælg type!");
+            return;
+        }
 
-    public class Assignment
-    {
-        public int Id { get; set; }
-        public string Title { get; set; } = "";
-    }
+        var dto = new CreateAssignmentSheetDto
+        {
+            TaskIds = SelectedAssignments.Select(a => a.Id).ToList(),
+            Type = SelectedType
+        };
 
+        var response = await Http.PostAsJsonAsync("http://localhost:5000/api/assignmentsheets", dto);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var pdfBytes = await response.Content.ReadAsByteArrayAsync();
+            Console.WriteLine("PDF modtaget!");
+        }
+        else
+        {
+            var error = await response.Content.ReadAsStringAsync();
+            Console.WriteLine(error);
+        }
+    }
 }

--- a/blazor/blazor/models/AssignmentSheet.cs
+++ b/blazor/blazor/models/AssignmentSheet.cs
@@ -1,0 +1,7 @@
+namespace blazor.models;
+
+public class AssignmentSheet
+{
+    public List<Assignment> Tasks { get; set; } = new();
+    public string Type { get; set; } = "";
+}

--- a/blazor/blazor/models/AssignmentSheetItem.cs
+++ b/blazor/blazor/models/AssignmentSheetItem.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace blazor.models
+{
+    public class AssignmentSheetItem
+    {
+        public Guid Id { get; set; }
+        public string Subject { get; set; } = "";
+        public string Topic { get; set; } = "";
+        public int Number { get; set; } = 1;
+    }
+}

--- a/blazor/blazor/models/CreateAssignmentSheetDto.cs
+++ b/blazor/blazor/models/CreateAssignmentSheetDto.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+
+namespace blazor.models
+{
+    public class CreateAssignmentSheetDto
+    {
+        public List<Guid> TaskIds { get; set; } = new List<Guid>();
+        public string Type { get; set; } = ""; // "prøve" eller "lektier"
+    }
+}


### PR DESCRIPTION
Implemented GET /api/assignment/with-id to fetch assignments with their IDs for assignment sheet creation.
Implemented POST /api/assignmentsheets to create an assignment sheet and generate a PDF.
Added CreateAssignmentSheetDto and AssignmentWithIdDTO to separate backend DTOs from frontend models.
Updated CreateAssignmentSheet.razor to:
* Fetch assignments including IDs
* Select multiple assignments
* Choose type (prøve or lektier)
* Send POST request with selected task IDs and type.

Integrated QuestPDF for generating assignment sheet PDFs.