### PR TITLE
fix(seed): align admin seed email with teacher/student pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Blazor WebAssembly frontend + ASP.NET Core Web API backend, with SQL Server (EF 
 
 | Role | Email | Password |
 | --- | --- | --- |
-| Admin | `admin@example.com` | `Admin1234!` |
+| Admin | `admin@admin.com` | `Admin1234!` |
 | Teacher | `teacher@teacher.com` | `Teacher1234!` |
 | Student | `student@student.com` | `Student1234!` |
 

--- a/backend/api/Data/DbSeeder.cs
+++ b/backend/api/Data/DbSeeder.cs
@@ -33,7 +33,7 @@ public class DbSeeder
 
         var users = new[]
         {
-            new { Email = "admin@example.com", Password = "Admin1234!", Role = Roles.Admin },
+            new { Email = "admin@admin.com", Password = "Admin1234!", Role = Roles.Admin },
             new { Email = "teacher@teacher.com", Password = "Teacher1234!", Role = Roles.Teacher },
             new { Email = "student@student.com", Password = "Student1234!", Role = Roles.Student }
         };


### PR DESCRIPTION
## Summary
- DbSeeder now creates the admin as `admin@admin.com` to match the existing
  `teacher@teacher.com` / `student@student.com` convention.
- README seed-account table updated to match.

## Test plan
- [ ] Wipe the DB, set `SeedDatabase=true`, boot the API
- [ ] Confirm you can log in as `admin@admin.com` / `Admin1234!`