### PR TITLE
fix(blazor): await Search from Reset so loading state resolves

### DIFF
--- a/blazor/blazor/Pages/FilterAssignments.razor
+++ b/blazor/blazor/Pages/FilterAssignments.razor
@@ -152,7 +152,7 @@ else if (result != null)
         }
     }
 
-    private void Reset()
+    private async Task Reset()
     {
         subject = level = topic = owner = tag = "";
         year = null;
@@ -160,7 +160,7 @@ else if (result != null)
         sortDir = "desc";
         page = 1;
         pageSize = 20;
-        _ = Search();
+        await Search();
     }
 
     private async Task PrevPage()


### PR DESCRIPTION
## Summary
- `Reset()` was sync and fired `Search()` as a detached task, so Blazor never
  re-rendered after the search finished — the "Indlæser..." indicator stayed
  on screen.
- Make `Reset` async and await `Search` so the lifecycle handles the rerender.

## Test plan
- [ ] Open Filtrér Opgaver, change a filter, hit Søg
- [ ] Click Nulstil — fields clear and the loading state goes away once the
      refreshed result arrives