### PR TITLE
refactor(pdf): drop redundant enum check in AssignmentSheetPdfService

### DIFF
--- a/backend/api/Services/AssignmentSheetPdfService.cs
+++ b/backend/api/Services/AssignmentSheetPdfService.cs
@@ -16,7 +16,7 @@ public class AssignmentSheetPdfService : IAssignmentSheetPdfService
 
     public byte[] GenerateAssignmentSheetPdf(AssignmentSheet sheet)
     {
-        var typeLabel = sheet.Type == AssignmentSheetType.Proeve ? "Prøve" : "Hjemmeopgave";
+        var typeLabel = sheet.Type.ToString();
 
         var document = Document.Create(container =>
         {


### PR DESCRIPTION
## Summary
- `sheet.Type` is a two-value enum (`Proeve` / `Hjemmeopgave`); the ternary
  added no value over a direct `ToString()`.

## Test plan
- [ ] Generate a PDF for a Prøve sheet — header reads "Proeve · …"
- [ ] Generate a PDF for a Hjemmeopgave sheet — header reads "Hjemmeopgave · …"