### PR TITLE
fix(auth): explicit StudentOrTeacher policy for Statistik-Elev page

### DIFF
--- a/blazor/blazor/Pages/Statistics.razor
+++ b/blazor/blazor/Pages/Statistics.razor
@@ -3,7 +3,7 @@
 @using blazor.models
 @using System.Globalization
 @using System.Net.Http.Json
-@attribute [Authorize(Roles = Roles.StudentOrTeacher)]
+@attribute [Authorize(Policy = "StudentOrTeacher")]
 @inject HttpClient Http
 
 <PageTitle>Statistik</PageTitle>

--- a/blazor/blazor/Program.cs
+++ b/blazor/blazor/Program.cs
@@ -3,6 +3,7 @@ using blazor.Services;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.AspNetCore.Components.Authorization;
+using Shared;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
@@ -19,6 +20,10 @@ builder.Services.AddScoped(sp => new HttpClient
     BaseAddress = new Uri(apiBaseUrl)
 });
 
-builder.Services.AddAuthorizationCore();
+builder.Services.AddAuthorizationCore(options =>
+{
+    options.AddPolicy("StudentOrTeacher", policy =>
+        policy.RequireRole(Roles.Student, Roles.Teacher));
+});
 
 await builder.Build().RunAsync();


### PR DESCRIPTION
## Summary
- `[Authorize(Roles = "Student,Teacher")]` doesn't always split the comma
  string reliably client-side in Blazor, blocking both Student and Teacher
  users from `/statistik-elev`.
- Register a `StudentOrTeacher` policy in `Program.cs` via `RequireRole`.
- Switch the page to `[Authorize(Policy = "StudentOrTeacher")]`.

## Test plan
- [ ] Log in as a Student, navigate to `/statistik-elev` — stats render
- [ ] Log in as a Teacher, navigate to `/statistik-elev` — stats render
- [ ] Log in as Admin (no Student/Teacher role) — page denies access