### PR TITLE
feat(docker): bring up the full stack with

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+**/bin
+**/obj
+**/.vs
+**/.vscode
+**/node_modules

--- a/backend/api/.dockerignore
+++ b/backend/api/.dockerignore
@@ -1,0 +1,5 @@
+**/bin
+**/obj
+**/.vs
+**/.vscode
+**/node_modules

--- a/backend/api/Dockerfile
+++ b/backend/api/Dockerfile
@@ -1,0 +1,19 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY Shared/Shared.csproj Shared/
+COPY backend/api/api.csproj backend/api/
+RUN dotnet restore backend/api/api.csproj
+
+COPY Shared/ Shared/
+COPY backend/api/ backend/api/
+RUN dotnet publish backend/api/api.csproj -c Release -o /app/publish /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/publish ./
+
+ENV ASPNETCORE_URLS=http://+:5000
+EXPOSE 5000
+
+ENTRYPOINT ["dotnet", "api.dll"]

--- a/blazor/blazor/Dockerfile
+++ b/blazor/blazor/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY Shared/Shared.csproj Shared/
+COPY blazor/blazor/blazor.csproj blazor/blazor/
+RUN dotnet restore blazor/blazor/blazor.csproj
+
+COPY Shared/ Shared/
+COPY blazor/blazor/ blazor/blazor/
+RUN dotnet publish blazor/blazor/blazor.csproj -c Release -o /app/publish
+
+FROM nginx:alpine AS runtime
+COPY --from=build /app/publish/wwwroot /usr/share/nginx/html
+EXPOSE 80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 # Usage
-# Start from CLI with:
+# Start everything (DBs + API + Blazor) from CLI with:
 # docker compose up -d
 #
 # Stop it from CLI with:
@@ -7,12 +7,6 @@
 #
 # Full reset from CLI (deletes volume):
 # docker compose down -v
-#
-# CLI
-# sqlcmd -S localhost,1433 -U SA -P "Th3_Stronkest_Paeswourt"
-# docker exec -it 1-Semester-MSSQL-DB /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P "$SA_PASSWORD"
-# docker exec -it 1-Semester-MongoDB mongosh "mongodb://admin:strongpassword@localhost:27017"
-version: "3.9"
 
 services:
 
@@ -28,6 +22,12 @@ services:
       - "1433:1433"
     volumes:
       - sql-data:/var/opt/mssql
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U SA -P \"$$SA_PASSWORD\" -C -Q 'SELECT 1' || /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P \"$$SA_PASSWORD\" -Q 'SELECT 1'"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
 
   mongodb:
     image: mongodb/mongodb-community-server:7.0-ubi8-slim
@@ -40,6 +40,49 @@ services:
     environment:
       MONGO_INITDB_ROOT_USERNAME: "${MONGO_ROOT_USERNAME}"
       MONGO_INITDB_ROOT_PASSWORD: "${MONGO_ROOT_PASSWORD}"
+    healthcheck:
+      test: ["CMD-SHELL", "mongosh --quiet --eval 'db.adminCommand({ping:1}).ok' | grep -q 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 15s
+
+  api:
+    build:
+      context: .
+      dockerfile: backend/api/Dockerfile
+    container_name: 1-Semester-API
+    restart: unless-stopped
+    depends_on:
+      sqlserver:
+        condition: service_healthy
+      mongodb:
+        condition: service_healthy
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_URLS: "http://+:5000"
+      ConnectionStrings__DefaultConnection: "Server=sqlserver,1433;Database=AssignmentBank;User Id=SA;Password=${SA_PASSWORD};TrustServerCertificate=True"
+      MongoDb__ConnectionString: "mongodb://${MONGO_ROOT_USERNAME}:${MONGO_ROOT_PASSWORD}@mongodb:27017"
+    ports:
+      - "5000:5000"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:5000/openapi/v1.json >/dev/null 2>&1 || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 6
+      start_period: 30s
+
+  blazor:
+    build:
+      context: .
+      dockerfile: blazor/blazor/Dockerfile
+    container_name: 1-Semester-Blazor
+    restart: unless-stopped
+    depends_on:
+      api:
+        condition: service_started
+    ports:
+      - "5050:80"
 
 volumes:
   sql-data:


### PR DESCRIPTION
## Summary
- Add Dockerfiles for the API (aspnet:10 runtime) and Blazor WASM (built and
  served by nginx).
- Extend `docker-compose.yml` with `api` and `blazor` services.
- Add healthchecks for SQL Server, MongoDB and the API.
- Wire `depends_on` so the API waits for both DBs to be healthy before it
  boots, and Blazor waits for the API to start.

`docker compose up -d` now boots the full stack with no manual steps.

## Test plan
- [ ] `cp .env.example .env`, fill values
- [ ] `docker compose up -d --build`
- [ ] `docker compose ps` — all four services healthy
- [ ] `http://localhost:5050` serves the Blazor SPA
- [ ] `http://localhost:5000/openapi/v1.json` returns the API spec