### PR TITLE
fix(spreadsheet): harden Excel export against empty sheets and font lookup

### DIFF
--- a/backend/api/Controllers/AssignmentSheetController.cs
+++ b/backend/api/Controllers/AssignmentSheetController.cs
@@ -145,7 +145,19 @@ public class AssignmentSheetController : ControllerBase
             return NotFound();
         }
 
-        var bytes = _spreadsheetService.GenerateAssignmentSheetSpreadsheet(sheet, marking);
+        byte[] bytes;
+        try
+        {
+            bytes = _spreadsheetService.GenerateAssignmentSheetSpreadsheet(sheet, marking);
+        }
+        catch (Exception ex)
+        {
+            return Problem(
+                title: "Failed to generate spreadsheet.",
+                detail: ex.Message,
+                statusCode: StatusCodes.Status500InternalServerError);
+        }
+
         var suffix = marking ? "retteark" : "regneark";
         var safeTitle = string.IsNullOrWhiteSpace(sheet.Title) ? "opgavesaet" : sheet.Title;
         var filename = $"{safeTitle}-{suffix}.xlsx";

--- a/backend/api/Services/SpreadsheetService.cs
+++ b/backend/api/Services/SpreadsheetService.cs
@@ -52,25 +52,30 @@ public class SpreadsheetService
         ws.Range(headerRow, 1, headerRow, 6).Style.Font.Bold = true;
         ws.Range(headerRow, 1, headerRow, 6).Style.Fill.BackgroundColor = XLColor.LightGray;
 
+        var assignments = sheet.Assignments?.OrderBy(a => a.Number).ToList() ?? new List<Assignment>();
+
         int row = headerRow + 1;
-        foreach (var a in sheet.Assignments.OrderBy(a => a.Number))
+        foreach (var a in assignments)
         {
             ws.Cell(row, 1).Value = a.Number;
-            ws.Cell(row, 2).Value = a.Topic;
-            ws.Cell(row, 3).Value = a.Subquestion;
+            ws.Cell(row, 2).Value = a.Topic ?? "";
+            ws.Cell(row, 3).Value = a.Subquestion ?? "";
             ws.Cell(row, 4).Value = a.Points;
             row++;
         }
 
-        int totalRow = row + 1;
-        ws.Cell(totalRow, 3).Value = "I alt:";
-        ws.Cell(totalRow, 3).Style.Font.Bold = true;
-        ws.Cell(totalRow, 4).FormulaA1 = $"SUM(D{headerRow + 1}:D{row - 1})";
-        ws.Cell(totalRow, 4).Style.Font.Bold = true;
-        ws.Cell(totalRow, 5).FormulaA1 = $"SUM(E{headerRow + 1}:E{row - 1})";
-        ws.Cell(totalRow, 5).Style.Font.Bold = true;
+        if (assignments.Count > 0)
+        {
+            int totalRow = row + 1;
+            ws.Cell(totalRow, 3).Value = "I alt:";
+            ws.Cell(totalRow, 3).Style.Font.Bold = true;
+            ws.Cell(totalRow, 4).FormulaA1 = $"SUM(D{headerRow + 1}:D{row - 1})";
+            ws.Cell(totalRow, 4).Style.Font.Bold = true;
+            ws.Cell(totalRow, 5).FormulaA1 = $"SUM(E{headerRow + 1}:E{row - 1})";
+            ws.Cell(totalRow, 5).Style.Font.Bold = true;
+        }
 
-        ws.Columns().AdjustToContents();
+        TryAdjustToContents(ws);
 
         using var ms = new MemoryStream();
         workbook.SaveAs(ms);
@@ -83,11 +88,11 @@ public class SpreadsheetService
         var ws = workbook.Worksheets.Add(markingSheet ? "Retteark" : "Regneark");
 
         ws.Cell(1, 1).Value = "Opgavesæt:";
-        ws.Cell(1, 2).Value = sheet.Title;
+        ws.Cell(1, 2).Value = sheet.Title ?? "";
         ws.Cell(2, 1).Value = "Fag:";
-        ws.Cell(2, 2).Value = sheet.Subject;
+        ws.Cell(2, 2).Value = sheet.Subject ?? "";
         ws.Cell(3, 1).Value = "Niveau:";
-        ws.Cell(3, 2).Value = sheet.Level;
+        ws.Cell(3, 2).Value = sheet.Level ?? "";
         ws.Cell(4, 1).Value = "År:";
         ws.Cell(4, 2).Value = sheet.Year;
 
@@ -112,12 +117,14 @@ public class SpreadsheetService
         ws.Range(headerRow, 1, headerRow, markingSheet ? 6 : 5).Style.Font.Bold = true;
         ws.Range(headerRow, 1, headerRow, markingSheet ? 6 : 5).Style.Fill.BackgroundColor = XLColor.LightGray;
 
+        var assignments = sheet.Assignments?.OrderBy(a => a.Number).ToList() ?? new List<Assignment>();
+
         int row = headerRow + 1;
-        foreach (var a in sheet.Assignments.OrderBy(a => a.Number))
+        foreach (var a in assignments)
         {
             ws.Cell(row, 1).Value = a.Number;
-            ws.Cell(row, 2).Value = a.Topic;
-            ws.Cell(row, 3).Value = a.Subquestion;
+            ws.Cell(row, 2).Value = a.Topic ?? "";
+            ws.Cell(row, 3).Value = a.Subquestion ?? "";
             ws.Cell(row, 4).Value = a.Points;
 
             if (!markingSheet)
@@ -128,21 +135,38 @@ public class SpreadsheetService
             row++;
         }
 
-        int totalRow = row + 1;
-        ws.Cell(totalRow, 3).Value = "I alt:";
-        ws.Cell(totalRow, 3).Style.Font.Bold = true;
-        ws.Cell(totalRow, 4).FormulaA1 = $"SUM(D{headerRow + 1}:D{row - 1})";
-        ws.Cell(totalRow, 4).Style.Font.Bold = true;
-        if (markingSheet)
+        if (assignments.Count > 0)
         {
-            ws.Cell(totalRow, 5).FormulaA1 = $"SUM(E{headerRow + 1}:E{row - 1})";
-            ws.Cell(totalRow, 5).Style.Font.Bold = true;
+            int totalRow = row + 1;
+            ws.Cell(totalRow, 3).Value = "I alt:";
+            ws.Cell(totalRow, 3).Style.Font.Bold = true;
+            ws.Cell(totalRow, 4).FormulaA1 = $"SUM(D{headerRow + 1}:D{row - 1})";
+            ws.Cell(totalRow, 4).Style.Font.Bold = true;
+            if (markingSheet)
+            {
+                ws.Cell(totalRow, 5).FormulaA1 = $"SUM(E{headerRow + 1}:E{row - 1})";
+                ws.Cell(totalRow, 5).Style.Font.Bold = true;
+            }
         }
 
-        ws.Columns().AdjustToContents();
+        TryAdjustToContents(ws);
 
         using var ms = new MemoryStream();
         workbook.SaveAs(ms);
         return ms.ToArray();
+    }
+
+    private static void TryAdjustToContents(IXLWorksheet ws)
+    {
+        try
+        {
+            ws.Columns().AdjustToContents();
+        }
+        catch
+        {
+            // ClosedXML's AdjustToContents depends on font/GDI lookups that are
+            // unavailable on some hosts (e.g. minimal Linux containers). Falling
+            // back to the default column widths keeps the export from crashing.
+        }
     }
 }


### PR DESCRIPTION
## Summary
The xlsx export crashed when:
- a sheet had no assignments (the SUM formula produced an inverted range), or
- ClosedXML's `AdjustToContents` couldn't resolve a font on the host.

Fixes:
- Guard against null `Assignments` and null string fields when writing cells.
- Skip the SUM-total block when there are zero rows.
- Wrap `AdjustToContents()` so a missing-font exception falls back to default
  column widths instead of crashing the request.
- Controller now translates a generation failure into a `ProblemDetails` 500
  response instead of letting the exception bubble.

## Test plan
- [ ] Download xlsx for a sheet with several assignments — opens cleanly,
      totals correct
- [ ] Download xlsx for a sheet with **zero** assignments — opens cleanly
      (no formula error)
- [ ] Force the spreadsheet service to throw — Blazor shows a status message,
      neither app crashes