### PR TITLE
fix(auth): await auth-state refresh before navigating after login

### DIFF
--- a/blazor/blazor/Pages/Login.razor
+++ b/blazor/blazor/Pages/Login.razor
@@ -26,7 +26,7 @@
             var result = await response.Content.ReadFromJsonAsync<LoginResult>();
             if (result != null)
             {
-                AuthService.SetToken(result.Token);
+                await AuthService.SetTokenAsync(result.Token);
 
                 var target = result.Role switch
                 {
@@ -36,10 +36,8 @@
                     _ => "/home"
                 };
 
-                message = $"Login lykkedes! Omdirigerer automatisk, vent venligst et øjeblik...";
+                message = $"Login lykkedes! Omdirigerer automatisk...";
                 StateHasChanged();
-
-                await Task.Delay(3000);
 
                 NavManager.NavigateTo(target);
             }

--- a/blazor/blazor/Services/ApiAuthStateProvider.cs
+++ b/blazor/blazor/Services/ApiAuthStateProvider.cs
@@ -46,10 +46,12 @@ public class ApiAuthStateProvider : AuthenticationStateProvider
         }
     }
 
-    public void NotifyUserAuthenticated()
+    public async Task NotifyUserAuthenticatedAsync()
     {
         _cached = null;
-        NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
+        var stateTask = GetAuthenticationStateAsync();
+        NotifyAuthenticationStateChanged(stateTask);
+        await stateTask;
     }
 
     public void NotifyUserSignedOut()

--- a/blazor/blazor/Services/AuthService.cs
+++ b/blazor/blazor/Services/AuthService.cs
@@ -4,7 +4,7 @@ namespace blazor.Services;
 
 public interface IAuthService
 {
-    void SetToken(string token);
+    Task SetTokenAsync(string token);
     void SignOut();
 }
 
@@ -19,13 +19,13 @@ public class AuthService : IAuthService
         this.authStateProvider = authStateProvider;
     }
 
-    public void SetToken(string token)
+    public async Task SetTokenAsync(string token)
     {
         http.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
 
         if (authStateProvider is ApiAuthStateProvider api)
         {
-            api.NotifyUserAuthenticated();
+            await api.NotifyUserAuthenticatedAsync();
         }
     }
 


### PR DESCRIPTION
## Summary
The login flow set the bearer token and fired
`NotifyAuthenticationStateChanged` without waiting for the `/api/account/me`
round-trip to settle. Navigation could then happen while `AuthorizeRouteView`
still cached the anonymous state — the target page rendered before its
`[Authorize]` guard saw the new claims and came up blank.

Fixes:
- `ApiAuthStateProvider.NotifyUserAuthenticatedAsync` returns a task that
  completes once the new state is fetched.
- `AuthService.SetTokenAsync` awaits it.
- `Login.razor` awaits `SetTokenAsync` before `NavigateTo`.
- Drop the cosmetic 3-second `Task.Delay` that was masking the race.

## Test plan
- [ ] Log in as Teacher → lands on `/teacher-dashboard` with full content
- [ ] Log in as Student → lands on `/student-dashboard` with full content
- [ ] Log out, log back in immediately — no blank page