### PR TITLE
test: add Arrange/Act/Assert section comments across the test suite

### DIFF
--- a/Tests/Data/AssignmentSheetRepositoryTests.cs
+++ b/Tests/Data/AssignmentSheetRepositoryTests.cs
@@ -20,23 +20,29 @@ public class AssignmentSheetRepositoryTests
     [Fact]
     public async Task DeleteAsync_ReturnsFalse_WhenSheetMissing()
     {
+        // Arrange
         var (repo, _) = Build();
 
+        // Act
         var result = await repo.DeleteAsync(Guid.NewGuid());
 
+        // Assert
         result.Should().BeFalse();
     }
 
     [Fact]
     public async Task DeleteAsync_RemovesSheet_AndReturnsTrue()
     {
+        // Arrange
         var (repo, ctx) = Build();
         var sheet = new AssignmentSheet { Id = Guid.NewGuid(), Title = "Test" };
         ctx.AssignmentSheets.Add(sheet);
         await ctx.SaveChangesAsync();
 
+        // Act
         var result = await repo.DeleteAsync(sheet.Id);
 
+        // Assert
         result.Should().BeTrue();
         (await ctx.AssignmentSheets.FindAsync(sheet.Id)).Should().BeNull();
     }
@@ -44,6 +50,7 @@ public class AssignmentSheetRepositoryTests
     [Fact]
     public async Task DeleteAsync_LeavesAssignmentsIntact_AndSetsFkToNull()
     {
+        // Arrange
         var (repo, ctx) = Build();
         var sheetId = Guid.NewGuid();
         var assignmentId = Guid.NewGuid();
@@ -57,8 +64,10 @@ public class AssignmentSheetRepositoryTests
         });
         await ctx.SaveChangesAsync();
 
+        // Act
         var deleted = await repo.DeleteAsync(sheetId);
 
+        // Assert
         deleted.Should().BeTrue();
         var surviving = await ctx.Assignments.FindAsync(assignmentId);
         surviving.Should().NotBeNull();

--- a/Tests/Services/AssignmentServiceTests.cs
+++ b/Tests/Services/AssignmentServiceTests.cs
@@ -22,16 +22,20 @@ public class AssignmentServiceTests
     [Fact]
     public async Task GetFiltered_Clamps_PageSize_To_100()
     {
+        // Arrange
         var (svc, _) = Build();
 
+        // Act
         var result = await svc.GetFiltered(null, null, null, null, null, null, null, page: 1, pageSize: 9999, sortBy: null, sortDir: null);
 
+        // Assert
         result.PageSize.Should().Be(100);
     }
 
     [Fact]
     public async Task GetFiltered_FiltersByTag()
     {
+        // Arrange
         var (svc, ctx) = Build();
         ctx.Assignments.AddRange(
             new Assignment { Id = Guid.NewGuid(), Subject = "M", Tags = new() { "calc", "easy" } },
@@ -39,14 +43,17 @@ public class AssignmentServiceTests
         );
         await ctx.SaveChangesAsync();
 
+        // Act
         var result = await svc.GetFiltered(null, null, null, null, null, "calc", null, 1, 20, null, null);
 
+        // Assert
         result.Total.Should().Be(1);
     }
 
     [Fact]
     public async Task GetFiltered_DefaultSort_IsByDate_Descending()
     {
+        // Arrange
         var (svc, ctx) = Build();
         var older = DateTime.Today.AddDays(-3);
         var newer = DateTime.Today;
@@ -56,8 +63,10 @@ public class AssignmentServiceTests
         );
         await ctx.SaveChangesAsync();
 
+        // Act
         var result = await svc.GetFiltered(null, null, null, null, null, null, null, 1, 20, null, "desc");
 
+        // Assert
         result.Items.First().Date.Should().Be(newer);
     }
 }

--- a/Tests/Services/SpreadsheetServiceTests.cs
+++ b/Tests/Services/SpreadsheetServiceTests.cs
@@ -25,8 +25,11 @@ public class SpreadsheetServiceTests
     [Fact]
     public void Generates_Regneark_With_Five_Header_Columns()
     {
+        // Arrange
+        // Act
         var bytes = new SpreadsheetService().GenerateAssignmentSheetSpreadsheet(SampleSheet(), markingSheet: false);
 
+        // Assert
         bytes.Should().NotBeNullOrEmpty();
         using var ms = new MemoryStream(bytes);
         using var wb = new XLWorkbook(ms);
@@ -38,8 +41,11 @@ public class SpreadsheetServiceTests
     [Fact]
     public void Generates_Retteark_With_Six_Header_Columns_And_SumFormula()
     {
+        // Arrange
+        // Act
         var bytes = new SpreadsheetService().GenerateAssignmentSheetSpreadsheet(SampleSheet(), markingSheet: true);
 
+        // Assert
         using var ms = new MemoryStream(bytes);
         using var wb = new XLWorkbook(ms);
         var ws = wb.Worksheets.First();

--- a/tests/Controllers/StudentsControllerTests.cs
+++ b/tests/Controllers/StudentsControllerTests.cs
@@ -27,13 +27,16 @@ public class StudentsControllerTests
     [ClassData(typeof(CreateStudentDTOTestData))]
     public async Task CreateStudent_WithClassData_Succeeds(CreateStudentDTO student)
     {
+        // Arrange
         var studentCon = CreateController();
         studentService
             .Setup(s => s.AddStudent(It.Is<Student>(st => st.FirstName == student.FirstName && st.LastName == student.LastName)))
             .ReturnsAsync(true);
 
+        // Act
         var result = await studentCon.CreateStudent(student);
 
+        // Assert
         result.Should().BeOfType<ActionResult<StudentResponseDTO>>();
         var created = result.Result.Should().BeOfType<CreatedAtActionResult>().Subject;
         var saved = created.Value.Should().BeOfType<StudentResponseDTO>().Subject;
@@ -94,12 +97,15 @@ public class StudentsControllerTests
     [Fact]
     public async Task DeleteStudent_WhenStudentExists_Succeeds()
     {
+        // Arrange
         var studentsCon = CreateController();
         var id = Guid.NewGuid();
         studentService.Setup(s => s.DeleteStudent(id)).ReturnsAsync(true);
 
+        // Act
         var result = await studentsCon.DeleteStudent(id);
 
+        // Assert
         result.Should().BeOfType<NoContentResult>();
         studentService.Verify(s => s.DeleteStudent(id), Times.Once);
     }
@@ -107,12 +113,15 @@ public class StudentsControllerTests
     [Fact]
     public async Task DeleteStudent_ReturnsNotFound_WhenStudentDoesntExist()
     {
+        // Arrange
         var studentsCon = CreateController();
         var id = Guid.NewGuid();
         studentService.Setup(s => s.DeleteStudent(id)).ReturnsAsync(false);
 
+        // Act
         var result = await studentsCon.DeleteStudent(id);
 
+        // Assert
         result.Should().BeOfType<NotFoundResult>();
         studentService.Verify(s => s.DeleteStudent(id), Times.Once);
     }


### PR DESCRIPTION
## Summary
- Normalize the AAA structure across xUnit tests: every `[Fact]` / `[Theory]`
  body is now split with `// Arrange`, `// Act`, `// Assert` markers in a
  consistent format.
- 4 files touched, 11 test methods updated (the rest already had AAA).

## Test plan
- [ ] `dotnet test Tests/Tests.csproj` — green