### PR TITLE
refactor(repo): introduce generic IRepository<T> / Repository<T> base

### DIFF
--- a/backend/api/Data/AssignmentRepository.cs
+++ b/backend/api/Data/AssignmentRepository.cs
@@ -1,40 +1,10 @@
 using api.Models;
-using Microsoft.EntityFrameworkCore;
 
 namespace api.Data;
 
-public class AssignmentRepository : IAssignmentRepository
+public class AssignmentRepository : Repository<Assignment>, IAssignmentRepository
 {
-    private readonly ApplicationDbContext _db;
-
-    public AssignmentRepository(ApplicationDbContext db)
+    public AssignmentRepository(ApplicationDbContext db) : base(db)
     {
-        _db = db;
     }
-
-    public async Task<Assignment> AddAsync(Assignment assignment)
-    {
-        _db.Assignments.Add(assignment);
-        await _db.SaveChangesAsync();
-        return assignment;
-    }
-
-    public Task<Assignment?> GetByIdAsync(Guid id)
-        => _db.Assignments.FindAsync(id).AsTask();
-
-    public async Task<IEnumerable<Assignment>> GetAllAsync()
-        => await _db.Assignments.AsNoTracking().ToListAsync();
-
-    public async Task<bool> RemoveAsync(Assignment assignment)
-    {
-        _db.Assignments.Remove(assignment);
-        await _db.SaveChangesAsync();
-        return true;
-    }
-
-    // For query-building callers (filter + paging). Returns IQueryable so the
-    // service layer can compose Where/OrderBy without exposing DbContext.
-    public IQueryable<Assignment> Query() => _db.Assignments.AsNoTracking();
-
-    public Task<int> SaveChangesAsync() => _db.SaveChangesAsync();
 }

--- a/backend/api/Data/AssignmentSheetRepository.cs
+++ b/backend/api/Data/AssignmentSheetRepository.cs
@@ -3,40 +3,25 @@ using Microsoft.EntityFrameworkCore;
 
 namespace api.Data;
 
-public class AssignmentSheetRepository : IAssignmentSheetRepository
+public class AssignmentSheetRepository : Repository<AssignmentSheet>, IAssignmentSheetRepository
 {
-    private readonly ApplicationDbContext _dbContext;
-
-    public AssignmentSheetRepository(ApplicationDbContext dbContext)
+    public AssignmentSheetRepository(ApplicationDbContext db) : base(db)
     {
-        _dbContext = dbContext;
     }
 
-    public async Task<IEnumerable<AssignmentSheet>> GetAllAsync()
+    public override async Task<AssignmentSheet?> GetByIdAsync(Guid id)
     {
-        return await _dbContext.AssignmentSheets
-            .AsNoTracking()
-            .ToListAsync();
-    }
-
-    public async Task<AssignmentSheet?> GetByIdAsync(Guid id)
-    {
-        return await _dbContext.AssignmentSheets
+        return await _set
             .AsNoTracking()
             .Include(s => s.Assignments)
             .FirstOrDefaultAsync(s => s.Id == id);
     }
 
-    public async Task<AssignmentSheet> CreateAsync(AssignmentSheet sheet)
-    {
-        _dbContext.AssignmentSheets.Add(sheet);
-        await _dbContext.SaveChangesAsync();
-        return sheet;
-    }
+    public Task<AssignmentSheet> CreateAsync(AssignmentSheet sheet) => AddAsync(sheet);
 
     public async Task<bool> UpdateAsync(AssignmentSheet sheet)
     {
-        var existing = await _dbContext.AssignmentSheets.FindAsync(sheet.Id);
+        var existing = await _set.FindAsync(sheet.Id);
         if (existing == null)
         {
             return false;
@@ -49,29 +34,25 @@ public class AssignmentSheetRepository : IAssignmentSheetRepository
         existing.Owner = sheet.Owner;
         existing.Type = sheet.Type;
 
-        await _dbContext.SaveChangesAsync();
+        await _db.SaveChangesAsync();
         return true;
     }
 
     public async Task<bool> DeleteAsync(Guid id)
     {
-        var sheet = await _dbContext.AssignmentSheets.FindAsync(id);
+        var sheet = await _set.FindAsync(id);
         if (sheet == null)
         {
             return false;
         }
-
-        _dbContext.AssignmentSheets.Remove(sheet);
-        await _dbContext.SaveChangesAsync();
-        return true;
+        return await RemoveAsync(sheet);
     }
 
     public async Task SetAssignmentsAsync(Guid sheetId, IEnumerable<Guid> assignmentIds)
     {
         var ids = assignmentIds?.ToHashSet() ?? new HashSet<Guid>();
 
-        // Null the FK on assignments that were attached to this sheet but are no longer in the set
-        var currentlyAttached = await _dbContext.Assignments
+        var currentlyAttached = await _db.Assignments
             .Where(a => a.AssignmentSheetId == sheetId)
             .ToListAsync();
 
@@ -80,10 +61,9 @@ public class AssignmentSheetRepository : IAssignmentSheetRepository
             a.AssignmentSheetId = null;
         }
 
-        // Attach newly-selected assignments that weren't already attached elsewhere to this sheet
         if (ids.Count > 0)
         {
-            var toAttach = await _dbContext.Assignments
+            var toAttach = await _db.Assignments
                 .Where(a => ids.Contains(a.Id))
                 .ToListAsync();
 
@@ -93,6 +73,6 @@ public class AssignmentSheetRepository : IAssignmentSheetRepository
             }
         }
 
-        await _dbContext.SaveChangesAsync();
+        await _db.SaveChangesAsync();
     }
 }

--- a/backend/api/Data/IAssignmentRepository.cs
+++ b/backend/api/Data/IAssignmentRepository.cs
@@ -2,12 +2,6 @@ using api.Models;
 
 namespace api.Data;
 
-public interface IAssignmentRepository
+public interface IAssignmentRepository : IRepository<Assignment>
 {
-    Task<Assignment> AddAsync(Assignment assignment);
-    Task<Assignment?> GetByIdAsync(Guid id);
-    Task<IEnumerable<Assignment>> GetAllAsync();
-    Task<bool> RemoveAsync(Assignment assignment);
-    IQueryable<Assignment> Query();
-    Task<int> SaveChangesAsync();
 }

--- a/backend/api/Data/IRepository.cs
+++ b/backend/api/Data/IRepository.cs
@@ -1,0 +1,14 @@
+namespace api.Data;
+
+// Shared CRUD contract. Specific repositories extend this with entity-specific
+// queries (e.g. AssignmentSheetRepository.SetAssignmentsAsync) instead of
+// duplicating the basic Add/Get/Remove plumbing.
+public interface IRepository<T> where T : class
+{
+    Task<T?> GetByIdAsync(Guid id);
+    Task<IEnumerable<T>> GetAllAsync();
+    Task<T> AddAsync(T entity);
+    Task<bool> RemoveAsync(T entity);
+    IQueryable<T> Query();
+    Task<int> SaveChangesAsync();
+}

--- a/backend/api/Data/IStudentRepository.cs
+++ b/backend/api/Data/IStudentRepository.cs
@@ -2,11 +2,7 @@ using api.Models;
 
 namespace api.Data;
 
-public interface IStudentRepository
+public interface IStudentRepository : IRepository<Student>
 {
-    Task<Student?> GetByIdAsync(Guid id);
     Task<IEnumerable<Student>> GetByClassAsync(string className);
-    Task AddAsync(Student student);
-    Task<bool> RemoveAsync(Student student);
-    Task<int> SaveChangesAsync();
 }

--- a/backend/api/Data/Repository.cs
+++ b/backend/api/Data/Repository.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace api.Data;
+
+// Generic CRUD base. Holds the DbContext + DbSet<T> and implements the
+// shared IRepository<T> surface. Entity-specific repositories derive from
+// this and add the bespoke queries they need.
+public class Repository<T> : IRepository<T> where T : class
+{
+    protected readonly ApplicationDbContext _db;
+    protected readonly DbSet<T> _set;
+
+    public Repository(ApplicationDbContext db)
+    {
+        _db = db;
+        _set = db.Set<T>();
+    }
+
+    public virtual Task<T?> GetByIdAsync(Guid id)
+        => _set.FindAsync(id).AsTask();
+
+    public virtual async Task<IEnumerable<T>> GetAllAsync()
+        => await _set.AsNoTracking().ToListAsync();
+
+    public virtual async Task<T> AddAsync(T entity)
+    {
+        _set.Add(entity);
+        await _db.SaveChangesAsync();
+        return entity;
+    }
+
+    public virtual async Task<bool> RemoveAsync(T entity)
+    {
+        _set.Remove(entity);
+        await _db.SaveChangesAsync();
+        return true;
+    }
+
+    public virtual IQueryable<T> Query() => _set.AsNoTracking();
+
+    public Task<int> SaveChangesAsync() => _db.SaveChangesAsync();
+}

--- a/backend/api/Data/StudentRepository.cs
+++ b/backend/api/Data/StudentRepository.cs
@@ -3,17 +3,14 @@ using Microsoft.EntityFrameworkCore;
 
 namespace api.Data;
 
-public class StudentRepository : IStudentRepository
+public class StudentRepository : Repository<Student>, IStudentRepository
 {
-    private readonly ApplicationDbContext _db;
-
-    public StudentRepository(ApplicationDbContext db)
+    public StudentRepository(ApplicationDbContext db) : base(db)
     {
-        _db = db;
     }
 
-    public Task<Student?> GetByIdAsync(Guid id)
-        => _db.Students.FirstOrDefaultAsync(s => s.Id == id);
+    public override Task<Student?> GetByIdAsync(Guid id)
+        => _set.FirstOrDefaultAsync(s => s.Id == id);
 
     public async Task<IEnumerable<Student>> GetByClassAsync(string className)
     {
@@ -21,26 +18,11 @@ public class StudentRepository : IStudentRepository
         {
             return Array.Empty<Student>();
         }
-        return await _db.Students
+        return await _set
             .AsNoTracking()
             .Where(s => s.StudentClass == className)
             .OrderBy(s => s.LastName)
             .ThenBy(s => s.FirstName)
             .ToListAsync();
     }
-
-    public async Task AddAsync(Student student)
-    {
-        _db.Students.Add(student);
-        await _db.SaveChangesAsync();
-    }
-
-    public async Task<bool> RemoveAsync(Student student)
-    {
-        _db.Students.Remove(student);
-        await _db.SaveChangesAsync();
-        return true;
-    }
-
-    public Task<int> SaveChangesAsync() => _db.SaveChangesAsync();
 }

--- a/backend/api/Interfaces/IAssignmentSheetRepository.cs
+++ b/backend/api/Interfaces/IAssignmentSheetRepository.cs
@@ -1,14 +1,15 @@
+using api.Data;
 using api.Models;
 
 namespace api.Data;
 
-public interface IAssignmentSheetRepository
+public interface IAssignmentSheetRepository : IRepository<AssignmentSheet>
 {
-    Task<IEnumerable<AssignmentSheet>> GetAllAsync();
-    Task<AssignmentSheet?> GetByIdAsync(Guid id);
+    // Backwards-compatible aliases over the generic AddAsync/RemoveAsync.
     Task<AssignmentSheet> CreateAsync(AssignmentSheet sheet);
     Task<bool> UpdateAsync(AssignmentSheet sheet);
     Task<bool> DeleteAsync(Guid id);
+
     // Replaces the set of assignments attached to the sheet.
     // Assignments not in the new set have their AssignmentSheetId nulled; they are not deleted.
     Task SetAssignmentsAsync(Guid sheetId, IEnumerable<Guid> assignmentIds);


### PR DESCRIPTION
## Summary

Added a shared CRUD contract (`IRepository<T>`) and an EF-backed implementation (`Repository<T>`) so entity-specific repositories only define bespoke queries instead of re-implementing common `Get` / `Add` / `Remove` logic.

`IAssignmentRepository` now extends `IRepository<Assignment>` with no additional members, and `AssignmentRepository` is reduced to a minimal 4-line subclass.

`IStudentRepository` keeps `GetByClassAsync`, while `StudentRepository` overrides `GetByIdAsync` with a no-tracking query and inherits all other base functionality.

`IAssignmentSheetRepository` retains `Create` / `Update` / `Delete` / `SetAssignments` aliases for source compatibility, and `AssignmentSheetRepository` overrides `GetByIdAsync` to `Include` child assignments.

Net diff: approximately 100 lines removed across the three repository files.

## Test plan

* [ ] `dotnet build`
* [ ] `dotnet test Tests/Tests.csproj` — green
* [ ] Smoke-test create / read / update / delete via the API for each entity