### PR TITLE
feat(sheet): mirror Assignment tag fields on AssignmentSheet

### DIFF
--- a/backend/api/Controllers/AssignmentSheetController.cs
+++ b/backend/api/Controllers/AssignmentSheetController.cs
@@ -74,7 +74,10 @@ public class AssignmentSheetController : ControllerBase
             Level = dto.Level,
             Year = dto.Year,
             Owner = string.IsNullOrWhiteSpace(dto.Owner) ? "Prøvebank" : dto.Owner,
-            Type = dto.Type
+            Type = dto.Type,
+            Topic = dto.Topic ?? "",
+            Education = dto.Education ?? "",
+            Tags = dto.Tags ?? new List<string>()
         };
 
         var created = await _assignmentSheetService.CreateAssignmentSheet(sheet, dto.AssignmentIds);
@@ -100,7 +103,10 @@ public class AssignmentSheetController : ControllerBase
             Level = dto.Level,
             Year = dto.Year,
             Owner = string.IsNullOrWhiteSpace(dto.Owner) ? "Prøvebank" : dto.Owner,
-            Type = dto.Type
+            Type = dto.Type,
+            Topic = dto.Topic ?? "",
+            Education = dto.Education ?? "",
+            Tags = dto.Tags ?? new List<string>()
         };
 
         var updated = await _assignmentSheetService.UpdateAssignmentSheet(sheet, dto.AssignmentIds);

--- a/backend/api/DTOs/AssignmentSheetResponseDTO.cs
+++ b/backend/api/DTOs/AssignmentSheetResponseDTO.cs
@@ -9,4 +9,7 @@ public record AssignmentSheetResponseDTO(
     string Level,
     int Year,
     string Owner,
-    AssignmentSheetType Type);
+    AssignmentSheetType Type,
+    string Topic,
+    string Education,
+    IReadOnlyList<string> Tags);

--- a/backend/api/DTOs/CreateAssignmentSheetDTO.cs
+++ b/backend/api/DTOs/CreateAssignmentSheetDTO.cs
@@ -12,6 +12,9 @@ public class CreateAssignmentSheetDTO
     public int Year { get; set; } = DateTime.Today.Year;
     public string Owner { get; set; } = "Prøvebank";
     public AssignmentSheetType Type { get; set; } = AssignmentSheetType.Hjemmeopgave;
+    public string Topic { get; set; } = "";
+    public string Education { get; set; } = "";
+    public List<string> Tags { get; set; } = new();
 
     // Optional: IDs of existing assignments to include in the new sheet.
     public List<Guid> AssignmentIds { get; set; } = new();

--- a/backend/api/DTOs/ResponseMapping.cs
+++ b/backend/api/DTOs/ResponseMapping.cs
@@ -13,7 +13,12 @@ public static class ResponseMapping
             a.Tags ?? new List<string>(), a.AssignmentSheetId);
 
     public static AssignmentSheetResponseDTO ToResponse(this AssignmentSheet s)
-        => new(s.Id, s.Title, s.Subject, s.Level, s.Year, s.Owner, s.Type);
+        => new(
+            s.Id, s.Title,
+            s.EffectiveSubject(), s.EffectiveLevel(),
+            s.Year, s.EffectiveOwner(), s.Type,
+            s.EffectiveTopic(), s.EffectiveEducation(),
+            s.EffectiveTags());
 
     public static StudentResponseDTO ToResponse(this Student s)
         => new(

--- a/backend/api/DTOs/UpdateAssignmentSheetDTO.cs
+++ b/backend/api/DTOs/UpdateAssignmentSheetDTO.cs
@@ -12,6 +12,9 @@ public class UpdateAssignmentSheetDTO
     public int Year { get; set; } = DateTime.Today.Year;
     public string Owner { get; set; } = "Prøvebank";
     public AssignmentSheetType Type { get; set; } = AssignmentSheetType.Hjemmeopgave;
+    public string Topic { get; set; } = "";
+    public string Education { get; set; } = "";
+    public List<string> Tags { get; set; } = new();
 
     // Replace the set of assignments attached to this sheet. If null, assignments are left untouched.
     public List<Guid>? AssignmentIds { get; set; }

--- a/backend/api/Data/AssignmentSheetRepository.cs
+++ b/backend/api/Data/AssignmentSheetRepository.cs
@@ -48,6 +48,9 @@ public class AssignmentSheetRepository : IAssignmentSheetRepository
         existing.Year = sheet.Year;
         existing.Owner = sheet.Owner;
         existing.Type = sheet.Type;
+        existing.Topic = sheet.Topic;
+        existing.Education = sheet.Education;
+        existing.Tags = sheet.Tags ?? new List<string>();
 
         await _dbContext.SaveChangesAsync();
         return true;

--- a/backend/api/Models/AssignmentSheet.cs
+++ b/backend/api/Models/AssignmentSheet.cs
@@ -12,6 +12,15 @@ public class AssignmentSheet
     public int Year { get; set; } = DateTime.Today.Year;
     public string Owner { get; set; } = "Prøvebank";
     public AssignmentSheetType Type { get; set; } = AssignmentSheetType.Hjemmeopgave;
+
+    // Sheet-level tag fields, mirroring Assignment so a sheet can carry its own
+    // metadata independent of the assignments it contains. When a sheet field is
+    // populated it OVERRIDES the corresponding aggregate computed from child
+    // assignments (see AssignmentSheetExtensions.EffectiveSubject etc.).
+    public string Topic { get; set; } = "";
+    public string Education { get; set; } = "";
+    public List<string> Tags { get; set; } = new List<string>();
+
     public List<Assignment> Assignments { get; set; } = new List<Assignment>();
 
     [Timestamp]

--- a/backend/api/Models/AssignmentSheetExtensions.cs
+++ b/backend/api/Models/AssignmentSheetExtensions.cs
@@ -1,0 +1,57 @@
+namespace api.Models;
+
+// Resolves the "effective" tag values for an AssignmentSheet.
+//
+// Overwrite rule: if the sheet itself has a non-empty value for a tag field,
+// the sheet wins. Otherwise we fall back to the most common value across the
+// sheet's child Assignments (so an "untagged" sheet still presents reasonable
+// metadata for filtering/display).
+public static class AssignmentSheetExtensions
+{
+    public static string EffectiveSubject(this AssignmentSheet sheet) =>
+        Pick(sheet.Subject, sheet.Assignments?.Select(a => a.Subject));
+
+    public static string EffectiveLevel(this AssignmentSheet sheet) =>
+        Pick(sheet.Level, sheet.Assignments?.Select(a => a.Level));
+
+    public static string EffectiveTopic(this AssignmentSheet sheet) =>
+        Pick(sheet.Topic, sheet.Assignments?.Select(a => a.Topic));
+
+    public static string EffectiveEducation(this AssignmentSheet sheet) =>
+        Pick(sheet.Education, sheet.Assignments?.Select(a => a.Education));
+
+    public static string EffectiveOwner(this AssignmentSheet sheet) =>
+        Pick(sheet.Owner, sheet.Assignments?.Select(a => a.Owner));
+
+    public static IReadOnlyList<string> EffectiveTags(this AssignmentSheet sheet)
+    {
+        if (sheet.Tags is { Count: > 0 })
+        {
+            return sheet.Tags;
+        }
+        return sheet.Assignments?
+            .SelectMany(a => a.Tags ?? Enumerable.Empty<string>())
+            .Where(t => !string.IsNullOrWhiteSpace(t))
+            .Distinct()
+            .ToList()
+            ?? new List<string>();
+    }
+
+    private static string Pick(string sheetValue, IEnumerable<string>? assignmentValues)
+    {
+        if (!string.IsNullOrWhiteSpace(sheetValue))
+        {
+            return sheetValue;
+        }
+        if (assignmentValues == null)
+        {
+            return "";
+        }
+        return assignmentValues
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .GroupBy(v => v)
+            .OrderByDescending(g => g.Count())
+            .Select(g => g.Key)
+            .FirstOrDefault() ?? "";
+    }
+}


### PR DESCRIPTION
## Summary

Mirrored Assignment’s tag fields on `AssignmentSheet` so a sheet can carry its own metadata by adding `Topic`, `Education`, and `Tags` to the model and DTOs.

Defined an explicit overwrite rule via `AssignmentSheetExtensions`:

* when the sheet has a non-empty value, the sheet value takes precedence
* otherwise the response falls back to the most common value across the sheet’s child `Assignments` (`Tags` falls back to the union of child tags)

Persisted the new columns through the create/update controller path and the repository’s `UpdateAsync`.

`AssignmentSheetResponseDTO` now exposes the resolved effective values to the client.

## ⚠️ Migration required before merge

```sh
dotnet ef migrations add AddSheetTagFields --project backend/api/api.csproj
dotnet ef database update --project backend/api/api.csproj
```

## Test plan

* [ ] Generate and apply the migration above
* [ ] Create a sheet with explicit `Topic = "Algebra"` — response returns `"Algebra"`
* [ ] Create a sheet with empty `Topic` and assignments tagged `Topic = "Geometry"` — response falls back to `"Geometry"`
* [ ] `Tags` array round-trips on create/update