### PR TITLE
feat(sheet): scope EditAssignmentSheet to teacher correction fields

### DIFF
--- a/backend/api/Controllers/AssignmentSheetController.cs
+++ b/backend/api/Controllers/AssignmentSheetController.cs
@@ -100,7 +100,10 @@ public class AssignmentSheetController : ControllerBase
             Level = dto.Level,
             Year = dto.Year,
             Owner = string.IsNullOrWhiteSpace(dto.Owner) ? "Prøvebank" : dto.Owner,
-            Type = dto.Type
+            Type = dto.Type,
+            Grade = dto.Grade ?? "",
+            Feedback = dto.Feedback ?? "",
+            CorrectionNotes = dto.CorrectionNotes ?? ""
         };
 
         var updated = await _assignmentSheetService.UpdateAssignmentSheet(sheet, dto.AssignmentIds);

--- a/backend/api/DTOs/AssignmentSheetResponseDTO.cs
+++ b/backend/api/DTOs/AssignmentSheetResponseDTO.cs
@@ -9,4 +9,7 @@ public record AssignmentSheetResponseDTO(
     string Level,
     int Year,
     string Owner,
-    AssignmentSheetType Type);
+    AssignmentSheetType Type,
+    string Grade,
+    string Feedback,
+    string CorrectionNotes);

--- a/backend/api/DTOs/ResponseMapping.cs
+++ b/backend/api/DTOs/ResponseMapping.cs
@@ -13,7 +13,8 @@ public static class ResponseMapping
             a.Tags ?? new List<string>(), a.AssignmentSheetId);
 
     public static AssignmentSheetResponseDTO ToResponse(this AssignmentSheet s)
-        => new(s.Id, s.Title, s.Subject, s.Level, s.Year, s.Owner, s.Type);
+        => new(s.Id, s.Title, s.Subject, s.Level, s.Year, s.Owner, s.Type,
+               s.Grade ?? "", s.Feedback ?? "", s.CorrectionNotes ?? "");
 
     public static StudentResponseDTO ToResponse(this Student s)
         => new(

--- a/backend/api/DTOs/UpdateAssignmentSheetDTO.cs
+++ b/backend/api/DTOs/UpdateAssignmentSheetDTO.cs
@@ -13,6 +13,10 @@ public class UpdateAssignmentSheetDTO
     public string Owner { get; set; } = "Prøvebank";
     public AssignmentSheetType Type { get; set; } = AssignmentSheetType.Hjemmeopgave;
 
+    public string Grade { get; set; } = "";
+    public string Feedback { get; set; } = "";
+    public string CorrectionNotes { get; set; } = "";
+
     // Replace the set of assignments attached to this sheet. If null, assignments are left untouched.
     public List<Guid>? AssignmentIds { get; set; }
 }

--- a/backend/api/Data/AssignmentSheetRepository.cs
+++ b/backend/api/Data/AssignmentSheetRepository.cs
@@ -48,6 +48,9 @@ public class AssignmentSheetRepository : IAssignmentSheetRepository
         existing.Year = sheet.Year;
         existing.Owner = sheet.Owner;
         existing.Type = sheet.Type;
+        existing.Grade = sheet.Grade;
+        existing.Feedback = sheet.Feedback;
+        existing.CorrectionNotes = sheet.CorrectionNotes;
 
         await _dbContext.SaveChangesAsync();
         return true;

--- a/backend/api/Models/AssignmentSheet.cs
+++ b/backend/api/Models/AssignmentSheet.cs
@@ -12,6 +12,12 @@ public class AssignmentSheet
     public int Year { get; set; } = DateTime.Today.Year;
     public string Owner { get; set; } = "Prøvebank";
     public AssignmentSheetType Type { get; set; } = AssignmentSheetType.Hjemmeopgave;
+
+    // Teacher correction context — populated when a sheet has been graded.
+    public string Grade { get; set; } = "";
+    public string Feedback { get; set; } = "";
+    public string CorrectionNotes { get; set; } = "";
+
     public List<Assignment> Assignments { get; set; } = new List<Assignment>();
 
     [Timestamp]

--- a/blazor/blazor/Pages/EditAssignmentSheet.razor
+++ b/blazor/blazor/Pages/EditAssignmentSheet.razor
@@ -27,45 +27,18 @@
         <div class="opgaver-container">
             <div class="opgave-block">
                 <div class="opgave-inputs">
-                    <label>Titel</label>
-                    <input type="text" @bind="form.Title" />
+                    <h2>@form.Title</h2>
 
-                    <label>Fag</label>
-                    <input type="text" @bind="form.Subject" />
+                    <label>Karakter</label>
+                    <input type="text" @bind="form.Grade" placeholder="f.eks. 12" />
 
-                    <label>Niveau</label>
-                    <input type="text" @bind="form.Level" />
+                    <label>Tilbagemelding til elev</label>
+                    <textarea rows="4" @bind="form.Feedback"></textarea>
 
-                    <label>År</label>
-                    <input type="number" @bind="form.Year" />
+                    <label>Rettenoter (intern)</label>
+                    <textarea rows="4" @bind="form.CorrectionNotes"></textarea>
 
-                    <label>Ejer</label>
-                    <input type="text" @bind="form.Owner" />
-
-                    <label>Type</label>
-                    <select @bind="form.Type">
-                        <option value="Hjemmeopgave">Hjemmeopgave</option>
-                        <option value="Proeve">Prøve</option>
-                    </select>
-
-                    <label>Opgaver (vælg de opgaver der skal indgå)</label>
-                    <input placeholder="Filter…" @bind="filter" @bind:event="oninput" />
-                    <div style="max-height:260px;overflow:auto;border:1px solid #ccc;padding:6px;">
-                        @foreach (var a in FilteredAssignments)
-                        {
-                            <label style="display:block;">
-                                <input type="checkbox"
-                                       checked="@form.AssignmentIds!.Contains(a.Id)"
-                                       @onchange="e => ToggleAssignment(a.Id, (bool)e.Value!)" />
-                                @a.Subject — @a.Topic (Opg. @a.Number, @a.Points p.)
-                            </label>
-                        }
-                    </div>
-                    <small>@form.AssignmentIds!.Count valgt</small>
-
-                    <button @onclick="Save" disabled="@string.IsNullOrWhiteSpace(form.Title)">
-                        Gem ændringer
-                    </button>
+                    <button @onclick="Save">Gem rettelse</button>
                 </div>
             </div>
         </div>
@@ -79,10 +52,8 @@
 
 @code {
     private List<AssignmentSheetSummary> sheets = new();
-    private List<Assignment> allAssignments = new();
     private string selectedId = "";
-    private string filter = "";
-    private UpdateAssignmentSheetDTO? form;
+    private CorrectionForm? form;
     private string status = "";
 
     protected override async Task OnInitializedAsync()
@@ -90,32 +61,10 @@
         try
         {
             sheets = await Http.GetFromJsonAsync<List<AssignmentSheetSummary>>("api/assignmentsheet") ?? new();
-            var paged = await Http.GetFromJsonAsync<PagedResult<Assignment>>("api/assignment?pageSize=200");
-            allAssignments = paged?.Items ?? new();
         }
         catch (Exception ex)
         {
             status = $"Kunne ikke hente data: {ex.Message}";
-        }
-    }
-
-    private IEnumerable<Assignment> FilteredAssignments =>
-        string.IsNullOrWhiteSpace(filter)
-            ? allAssignments
-            : allAssignments.Where(a =>
-                (a.Subject?.Contains(filter, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                (a.Topic?.Contains(filter, StringComparison.OrdinalIgnoreCase) ?? false));
-
-    private void ToggleAssignment(Guid id, bool isChecked)
-    {
-        if (form?.AssignmentIds is null) return;
-        if (isChecked)
-        {
-            if (!form.AssignmentIds.Contains(id)) form.AssignmentIds.Add(id);
-        }
-        else
-        {
-            form.AssignmentIds.Remove(id);
         }
     }
 
@@ -127,12 +76,7 @@
             var sheet = await Http.GetFromJsonAsync<AssignmentSheetSummary>($"api/assignmentsheet/{selectedId}");
             if (sheet is null) { status = "Opgavesæt ikke fundet."; return; }
 
-            var currentAssignmentIds = allAssignments
-                .Where(a => a.AssignmentSheetId == sheet.Id)
-                .Select(a => a.Id)
-                .ToList();
-
-            form = new UpdateAssignmentSheetDTO
+            form = new CorrectionForm
             {
                 Title = sheet.Title,
                 Subject = sheet.Subject,
@@ -140,7 +84,9 @@
                 Year = sheet.Year,
                 Owner = sheet.Owner,
                 Type = sheet.Type,
-                AssignmentIds = currentAssignmentIds
+                Grade = sheet.Grade ?? "",
+                Feedback = sheet.Feedback ?? "",
+                CorrectionNotes = sheet.CorrectionNotes ?? ""
             };
             status = "";
         }
@@ -156,8 +102,8 @@
         var response = await Http.PutAsJsonAsync($"api/assignmentsheet/{selectedId}", form);
         if (response.IsSuccessStatusCode)
         {
-            status = $"Opgavesæt '{form.Title}' opdateret.";
-            await Task.Delay(1200);
+            status = $"Rettelse gemt for '{form.Title}'.";
+            await Task.Delay(800);
             Navigation.NavigateTo("/assignment-sheet-overview");
         }
         else
@@ -175,9 +121,15 @@
         public int Year { get; set; }
         public string Owner { get; set; } = "";
         public AssignmentSheetType Type { get; set; }
+        public string? Grade { get; set; }
+        public string? Feedback { get; set; }
+        public string? CorrectionNotes { get; set; }
     }
 
-    public class UpdateAssignmentSheetDTO
+    // Server-side UpdateAssignmentSheetDTO carries metadata fields too; we
+    // simply preserve what we loaded for them and surface only the correction
+    // fields to the teacher.
+    public class CorrectionForm
     {
         public string Title { get; set; } = "";
         public string Subject { get; set; } = "";
@@ -185,6 +137,8 @@
         public int Year { get; set; } = DateTime.Today.Year;
         public string Owner { get; set; } = "Prøvebank";
         public AssignmentSheetType Type { get; set; } = AssignmentSheetType.Hjemmeopgave;
-        public List<Guid>? AssignmentIds { get; set; } = new();
+        public string Grade { get; set; } = "";
+        public string Feedback { get; set; } = "";
+        public string CorrectionNotes { get; set; } = "";
     }
 }


### PR DESCRIPTION
## Summary

The edit page previously exposed full sheet metadata (`Subject`, `Level`, `Year`, `Owner`, `Type`, and full assignment selection), which does not belong in a teacher-correction workflow.

Added `Grade`, `Feedback`, and `CorrectionNotes` to `AssignmentSheet`, the update DTO, the response DTO, and the repository’s `UpdateAsync`.

Rewrote `EditAssignmentSheet.razor` to surface only those correction-related fields, along with the sheet title for context.

## ⚠️ Migration required before merge

```sh
dotnet ef migrations add AddSheetCorrectionFields --project backend/api/api.csproj
dotnet ef database update --project backend/api/api.csproj
```

If merging together with #task/2, generate one combined migration instead.

## Test plan

* [ ] Generate and apply the migration above
* [ ] Open `/edit-assignment-sheet`, pick a sheet, and click **Hent**
* [ ] Verify the form shows only the title (read-only) plus `Karakter`, `Tilbagemelding`, and `Rettenoter` inputs
* [ ] Save → values persist and the page redirects to `/assignment-sheet-overview`