### PR TITLE
feat(sheet): metadata + correction fields with combined EF migration

### DIFF
--- a/backend/api/Controllers/AssignmentSheetController.cs
+++ b/backend/api/Controllers/AssignmentSheetController.cs
@@ -106,7 +106,10 @@ public class AssignmentSheetController : ControllerBase
             Type = dto.Type,
             Topic = dto.Topic ?? "",
             Education = dto.Education ?? "",
-            Tags = dto.Tags ?? new List<string>()
+            Tags = dto.Tags ?? new List<string>(),
+            Grade = dto.Grade ?? "",
+            Feedback = dto.Feedback ?? "",
+            CorrectionNotes = dto.CorrectionNotes ?? ""
         };
 
         var updated = await _assignmentSheetService.UpdateAssignmentSheet(sheet, dto.AssignmentIds);

--- a/backend/api/Controllers/AssignmentSheetController.cs
+++ b/backend/api/Controllers/AssignmentSheetController.cs
@@ -74,7 +74,10 @@ public class AssignmentSheetController : ControllerBase
             Level = dto.Level,
             Year = dto.Year,
             Owner = string.IsNullOrWhiteSpace(dto.Owner) ? "Prøvebank" : dto.Owner,
-            Type = dto.Type
+            Type = dto.Type,
+            Topic = dto.Topic ?? "",
+            Education = dto.Education ?? "",
+            Tags = dto.Tags ?? new List<string>()
         };
 
         var created = await _assignmentSheetService.CreateAssignmentSheet(sheet, dto.AssignmentIds);
@@ -100,7 +103,10 @@ public class AssignmentSheetController : ControllerBase
             Level = dto.Level,
             Year = dto.Year,
             Owner = string.IsNullOrWhiteSpace(dto.Owner) ? "Prøvebank" : dto.Owner,
-            Type = dto.Type
+            Type = dto.Type,
+            Topic = dto.Topic ?? "",
+            Education = dto.Education ?? "",
+            Tags = dto.Tags ?? new List<string>()
         };
 
         var updated = await _assignmentSheetService.UpdateAssignmentSheet(sheet, dto.AssignmentIds);

--- a/backend/api/DTOs/AssignmentSheetResponseDTO.cs
+++ b/backend/api/DTOs/AssignmentSheetResponseDTO.cs
@@ -12,4 +12,7 @@ public record AssignmentSheetResponseDTO(
     AssignmentSheetType Type,
     string Topic,
     string Education,
-    IReadOnlyList<string> Tags);
+    IReadOnlyList<string> Tags,
+    string Grade,
+    string Feedback,
+    string CorrectionNotes);

--- a/backend/api/DTOs/AssignmentSheetResponseDTO.cs
+++ b/backend/api/DTOs/AssignmentSheetResponseDTO.cs
@@ -9,4 +9,7 @@ public record AssignmentSheetResponseDTO(
     string Level,
     int Year,
     string Owner,
-    AssignmentSheetType Type);
+    AssignmentSheetType Type,
+    string Topic,
+    string Education,
+    IReadOnlyList<string> Tags);

--- a/backend/api/DTOs/CreateAssignmentSheetDTO.cs
+++ b/backend/api/DTOs/CreateAssignmentSheetDTO.cs
@@ -12,6 +12,9 @@ public class CreateAssignmentSheetDTO
     public int Year { get; set; } = DateTime.Today.Year;
     public string Owner { get; set; } = "Prøvebank";
     public AssignmentSheetType Type { get; set; } = AssignmentSheetType.Hjemmeopgave;
+    public string Topic { get; set; } = "";
+    public string Education { get; set; } = "";
+    public List<string> Tags { get; set; } = new();
 
     // Optional: IDs of existing assignments to include in the new sheet.
     public List<Guid> AssignmentIds { get; set; } = new();

--- a/backend/api/DTOs/ResponseMapping.cs
+++ b/backend/api/DTOs/ResponseMapping.cs
@@ -18,7 +18,8 @@ public static class ResponseMapping
             s.EffectiveSubject(), s.EffectiveLevel(),
             s.Year, s.EffectiveOwner(), s.Type,
             s.EffectiveTopic(), s.EffectiveEducation(),
-            s.EffectiveTags());
+            s.EffectiveTags(),
+            s.Grade ?? "", s.Feedback ?? "", s.CorrectionNotes ?? "");
 
     public static StudentResponseDTO ToResponse(this Student s)
         => new(

--- a/backend/api/DTOs/ResponseMapping.cs
+++ b/backend/api/DTOs/ResponseMapping.cs
@@ -13,7 +13,12 @@ public static class ResponseMapping
             a.Tags ?? new List<string>(), a.AssignmentSheetId);
 
     public static AssignmentSheetResponseDTO ToResponse(this AssignmentSheet s)
-        => new(s.Id, s.Title, s.Subject, s.Level, s.Year, s.Owner, s.Type);
+        => new(
+            s.Id, s.Title,
+            s.EffectiveSubject(), s.EffectiveLevel(),
+            s.Year, s.EffectiveOwner(), s.Type,
+            s.EffectiveTopic(), s.EffectiveEducation(),
+            s.EffectiveTags());
 
     public static StudentResponseDTO ToResponse(this Student s)
         => new(

--- a/backend/api/DTOs/UpdateAssignmentSheetDTO.cs
+++ b/backend/api/DTOs/UpdateAssignmentSheetDTO.cs
@@ -12,6 +12,9 @@ public class UpdateAssignmentSheetDTO
     public int Year { get; set; } = DateTime.Today.Year;
     public string Owner { get; set; } = "Prøvebank";
     public AssignmentSheetType Type { get; set; } = AssignmentSheetType.Hjemmeopgave;
+    public string Topic { get; set; } = "";
+    public string Education { get; set; } = "";
+    public List<string> Tags { get; set; } = new();
 
     // Replace the set of assignments attached to this sheet. If null, assignments are left untouched.
     public List<Guid>? AssignmentIds { get; set; }

--- a/backend/api/DTOs/UpdateAssignmentSheetDTO.cs
+++ b/backend/api/DTOs/UpdateAssignmentSheetDTO.cs
@@ -16,6 +16,10 @@ public class UpdateAssignmentSheetDTO
     public string Education { get; set; } = "";
     public List<string> Tags { get; set; } = new();
 
+    public string Grade { get; set; } = "";
+    public string Feedback { get; set; } = "";
+    public string CorrectionNotes { get; set; } = "";
+
     // Replace the set of assignments attached to this sheet. If null, assignments are left untouched.
     public List<Guid>? AssignmentIds { get; set; }
 }

--- a/backend/api/Data/AssignmentSheetRepository.cs
+++ b/backend/api/Data/AssignmentSheetRepository.cs
@@ -48,6 +48,9 @@ public class AssignmentSheetRepository : IAssignmentSheetRepository
         existing.Year = sheet.Year;
         existing.Owner = sheet.Owner;
         existing.Type = sheet.Type;
+        existing.Topic = sheet.Topic;
+        existing.Education = sheet.Education;
+        existing.Tags = sheet.Tags ?? new List<string>();
 
         await _dbContext.SaveChangesAsync();
         return true;

--- a/backend/api/Data/AssignmentSheetRepository.cs
+++ b/backend/api/Data/AssignmentSheetRepository.cs
@@ -51,6 +51,9 @@ public class AssignmentSheetRepository : IAssignmentSheetRepository
         existing.Topic = sheet.Topic;
         existing.Education = sheet.Education;
         existing.Tags = sheet.Tags ?? new List<string>();
+        existing.Grade = sheet.Grade;
+        existing.Feedback = sheet.Feedback;
+        existing.CorrectionNotes = sheet.CorrectionNotes;
 
         await _dbContext.SaveChangesAsync();
         return true;

--- a/backend/api/Migrations/20260426041152_AddSheetMetadataAndCorrection.Designer.cs
+++ b/backend/api/Migrations/20260426041152_AddSheetMetadataAndCorrection.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using api.Data;
 
@@ -11,9 +12,11 @@ using api.Data;
 namespace api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260426041152_AddSheetMetadataAndCorrection")]
+    partial class AddSheetMetadataAndCorrection
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/api/Migrations/20260426041152_AddSheetMetadataAndCorrection.cs
+++ b/backend/api/Migrations/20260426041152_AddSheetMetadataAndCorrection.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSheetMetadataAndCorrection : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CorrectionNotes",
+                table: "AssignmentSheets",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Education",
+                table: "AssignmentSheets",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Feedback",
+                table: "AssignmentSheets",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Grade",
+                table: "AssignmentSheets",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Tags",
+                table: "AssignmentSheets",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "[]");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Topic",
+                table: "AssignmentSheets",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CorrectionNotes",
+                table: "AssignmentSheets");
+
+            migrationBuilder.DropColumn(
+                name: "Education",
+                table: "AssignmentSheets");
+
+            migrationBuilder.DropColumn(
+                name: "Feedback",
+                table: "AssignmentSheets");
+
+            migrationBuilder.DropColumn(
+                name: "Grade",
+                table: "AssignmentSheets");
+
+            migrationBuilder.DropColumn(
+                name: "Tags",
+                table: "AssignmentSheets");
+
+            migrationBuilder.DropColumn(
+                name: "Topic",
+                table: "AssignmentSheets");
+        }
+    }
+}

--- a/backend/api/Models/AssignmentSheet.cs
+++ b/backend/api/Models/AssignmentSheet.cs
@@ -21,6 +21,11 @@ public class AssignmentSheet
     public string Education { get; set; } = "";
     public List<string> Tags { get; set; } = new List<string>();
 
+    // Teacher correction context — populated when a sheet has been graded.
+    public string Grade { get; set; } = "";
+    public string Feedback { get; set; } = "";
+    public string CorrectionNotes { get; set; } = "";
+
     public List<Assignment> Assignments { get; set; } = new List<Assignment>();
 
     [Timestamp]

--- a/backend/api/Models/AssignmentSheet.cs
+++ b/backend/api/Models/AssignmentSheet.cs
@@ -12,6 +12,15 @@ public class AssignmentSheet
     public int Year { get; set; } = DateTime.Today.Year;
     public string Owner { get; set; } = "Prøvebank";
     public AssignmentSheetType Type { get; set; } = AssignmentSheetType.Hjemmeopgave;
+
+    // Sheet-level tag fields, mirroring Assignment so a sheet can carry its own
+    // metadata independent of the assignments it contains. When a sheet field is
+    // populated it OVERRIDES the corresponding aggregate computed from child
+    // assignments (see AssignmentSheetExtensions.EffectiveSubject etc.).
+    public string Topic { get; set; } = "";
+    public string Education { get; set; } = "";
+    public List<string> Tags { get; set; } = new List<string>();
+
     public List<Assignment> Assignments { get; set; } = new List<Assignment>();
 
     [Timestamp]

--- a/backend/api/Models/AssignmentSheetExtensions.cs
+++ b/backend/api/Models/AssignmentSheetExtensions.cs
@@ -1,0 +1,57 @@
+namespace api.Models;
+
+// Resolves the "effective" tag values for an AssignmentSheet.
+//
+// Overwrite rule: if the sheet itself has a non-empty value for a tag field,
+// the sheet wins. Otherwise we fall back to the most common value across the
+// sheet's child Assignments (so an "untagged" sheet still presents reasonable
+// metadata for filtering/display).
+public static class AssignmentSheetExtensions
+{
+    public static string EffectiveSubject(this AssignmentSheet sheet) =>
+        Pick(sheet.Subject, sheet.Assignments?.Select(a => a.Subject));
+
+    public static string EffectiveLevel(this AssignmentSheet sheet) =>
+        Pick(sheet.Level, sheet.Assignments?.Select(a => a.Level));
+
+    public static string EffectiveTopic(this AssignmentSheet sheet) =>
+        Pick(sheet.Topic, sheet.Assignments?.Select(a => a.Topic));
+
+    public static string EffectiveEducation(this AssignmentSheet sheet) =>
+        Pick(sheet.Education, sheet.Assignments?.Select(a => a.Education));
+
+    public static string EffectiveOwner(this AssignmentSheet sheet) =>
+        Pick(sheet.Owner, sheet.Assignments?.Select(a => a.Owner));
+
+    public static IReadOnlyList<string> EffectiveTags(this AssignmentSheet sheet)
+    {
+        if (sheet.Tags is { Count: > 0 })
+        {
+            return sheet.Tags;
+        }
+        return sheet.Assignments?
+            .SelectMany(a => a.Tags ?? Enumerable.Empty<string>())
+            .Where(t => !string.IsNullOrWhiteSpace(t))
+            .Distinct()
+            .ToList()
+            ?? new List<string>();
+    }
+
+    private static string Pick(string sheetValue, IEnumerable<string>? assignmentValues)
+    {
+        if (!string.IsNullOrWhiteSpace(sheetValue))
+        {
+            return sheetValue;
+        }
+        if (assignmentValues == null)
+        {
+            return "";
+        }
+        return assignmentValues
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .GroupBy(v => v)
+            .OrderByDescending(g => g.Count())
+            .Select(g => g.Key)
+            .FirstOrDefault() ?? "";
+    }
+}

--- a/blazor/blazor/Pages/EditAssignmentSheet.razor
+++ b/blazor/blazor/Pages/EditAssignmentSheet.razor
@@ -27,45 +27,18 @@
         <div class="opgaver-container">
             <div class="opgave-block">
                 <div class="opgave-inputs">
-                    <label>Titel</label>
-                    <input type="text" @bind="form.Title" />
+                    <h2>@form.Title</h2>
 
-                    <label>Fag</label>
-                    <input type="text" @bind="form.Subject" />
+                    <label>Karakter</label>
+                    <input type="text" @bind="form.Grade" placeholder="f.eks. 12" />
 
-                    <label>Niveau</label>
-                    <input type="text" @bind="form.Level" />
+                    <label>Tilbagemelding til elev</label>
+                    <textarea rows="4" @bind="form.Feedback"></textarea>
 
-                    <label>År</label>
-                    <input type="number" @bind="form.Year" />
+                    <label>Rettenoter (intern)</label>
+                    <textarea rows="4" @bind="form.CorrectionNotes"></textarea>
 
-                    <label>Ejer</label>
-                    <input type="text" @bind="form.Owner" />
-
-                    <label>Type</label>
-                    <select @bind="form.Type">
-                        <option value="Hjemmeopgave">Hjemmeopgave</option>
-                        <option value="Proeve">Prøve</option>
-                    </select>
-
-                    <label>Opgaver (vælg de opgaver der skal indgå)</label>
-                    <input placeholder="Filter…" @bind="filter" @bind:event="oninput" />
-                    <div style="max-height:260px;overflow:auto;border:1px solid #ccc;padding:6px;">
-                        @foreach (var a in FilteredAssignments)
-                        {
-                            <label style="display:block;">
-                                <input type="checkbox"
-                                       checked="@form.AssignmentIds!.Contains(a.Id)"
-                                       @onchange="e => ToggleAssignment(a.Id, (bool)e.Value!)" />
-                                @a.Subject — @a.Topic (Opg. @a.Number, @a.Points p.)
-                            </label>
-                        }
-                    </div>
-                    <small>@form.AssignmentIds!.Count valgt</small>
-
-                    <button @onclick="Save" disabled="@string.IsNullOrWhiteSpace(form.Title)">
-                        Gem ændringer
-                    </button>
+                    <button @onclick="Save">Gem rettelse</button>
                 </div>
             </div>
         </div>
@@ -79,10 +52,8 @@
 
 @code {
     private List<AssignmentSheetSummary> sheets = new();
-    private List<Assignment> allAssignments = new();
     private string selectedId = "";
-    private string filter = "";
-    private UpdateAssignmentSheetDTO? form;
+    private CorrectionForm? form;
     private string status = "";
 
     protected override async Task OnInitializedAsync()
@@ -90,32 +61,10 @@
         try
         {
             sheets = await Http.GetFromJsonAsync<List<AssignmentSheetSummary>>("api/assignmentsheet") ?? new();
-            var paged = await Http.GetFromJsonAsync<PagedResult<Assignment>>("api/assignment?pageSize=200");
-            allAssignments = paged?.Items ?? new();
         }
         catch (Exception ex)
         {
             status = $"Kunne ikke hente data: {ex.Message}";
-        }
-    }
-
-    private IEnumerable<Assignment> FilteredAssignments =>
-        string.IsNullOrWhiteSpace(filter)
-            ? allAssignments
-            : allAssignments.Where(a =>
-                (a.Subject?.Contains(filter, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                (a.Topic?.Contains(filter, StringComparison.OrdinalIgnoreCase) ?? false));
-
-    private void ToggleAssignment(Guid id, bool isChecked)
-    {
-        if (form?.AssignmentIds is null) return;
-        if (isChecked)
-        {
-            if (!form.AssignmentIds.Contains(id)) form.AssignmentIds.Add(id);
-        }
-        else
-        {
-            form.AssignmentIds.Remove(id);
         }
     }
 
@@ -127,12 +76,7 @@
             var sheet = await Http.GetFromJsonAsync<AssignmentSheetSummary>($"api/assignmentsheet/{selectedId}");
             if (sheet is null) { status = "Opgavesæt ikke fundet."; return; }
 
-            var currentAssignmentIds = allAssignments
-                .Where(a => a.AssignmentSheetId == sheet.Id)
-                .Select(a => a.Id)
-                .ToList();
-
-            form = new UpdateAssignmentSheetDTO
+            form = new CorrectionForm
             {
                 Title = sheet.Title,
                 Subject = sheet.Subject,
@@ -140,7 +84,9 @@
                 Year = sheet.Year,
                 Owner = sheet.Owner,
                 Type = sheet.Type,
-                AssignmentIds = currentAssignmentIds
+                Grade = sheet.Grade ?? "",
+                Feedback = sheet.Feedback ?? "",
+                CorrectionNotes = sheet.CorrectionNotes ?? ""
             };
             status = "";
         }
@@ -156,8 +102,8 @@
         var response = await Http.PutAsJsonAsync($"api/assignmentsheet/{selectedId}", form);
         if (response.IsSuccessStatusCode)
         {
-            status = $"Opgavesæt '{form.Title}' opdateret.";
-            await Task.Delay(1200);
+            status = $"Rettelse gemt for '{form.Title}'.";
+            await Task.Delay(800);
             Navigation.NavigateTo("/assignment-sheet-overview");
         }
         else
@@ -175,9 +121,15 @@
         public int Year { get; set; }
         public string Owner { get; set; } = "";
         public AssignmentSheetType Type { get; set; }
+        public string? Grade { get; set; }
+        public string? Feedback { get; set; }
+        public string? CorrectionNotes { get; set; }
     }
 
-    public class UpdateAssignmentSheetDTO
+    // Server-side UpdateAssignmentSheetDTO carries metadata fields too; we
+    // simply preserve what we loaded for them and surface only the correction
+    // fields to the teacher.
+    public class CorrectionForm
     {
         public string Title { get; set; } = "";
         public string Subject { get; set; } = "";
@@ -185,6 +137,8 @@
         public int Year { get; set; } = DateTime.Today.Year;
         public string Owner { get; set; } = "Prøvebank";
         public AssignmentSheetType Type { get; set; } = AssignmentSheetType.Hjemmeopgave;
-        public List<Guid>? AssignmentIds { get; set; } = new();
+        public string Grade { get; set; } = "";
+        public string Feedback { get; set; } = "";
+        public string CorrectionNotes { get; set; } = "";
     }
 }


### PR DESCRIPTION
## Summary
Combines the two formerly-separate sheet-field PRs into one cohesive change
so a single EF migration covers all six new columns.

**From task 2 (metadata):**
- `Topic`, `Education`, `Tags` on `AssignmentSheet` + create/update DTOs
- `AssignmentSheetExtensions` with `EffectiveSubject` / `Level` / `Topic` /
  `Education` / `Owner` / `Tags` — sheet wins when populated, otherwise
  falls back to the most-common value across child assignments (Tags
  falls back to the union of child tags)
- Persist new columns through controller create/update path and the
  repository's `UpdateAsync`
- `AssignmentSheetResponseDTO` now exposes the resolved "effective" values

**From task 11 (correction):**
- `Grade`, `Feedback`, `CorrectionNotes` on `AssignmentSheet` + update DTO + response DTO
- `EditAssignmentSheet.razor` rewritten to surface only the sheet title (read-only context) plus Karakter / Tilbagemelding / Rettenoter — generic metadata fields like Owner are no longer editable in the correction view

## EF migration
`AddSheetMetadataAndCorrection` — single migration adding the six new
columns to the `AssignmentSheets` table. No data backfill needed; defaults
are `""` (or `"[]"` for the `Tags` JSON collection).

## Supersedes
- `assignmentsheet-tag-fields` (task 2)
- `edit-sheet-correction-fields` (task 11)

Please close those two PRs in favor of this one — same code, but split
across two branches and without a migration.

## Build / test
- `dotnet build 1st-semester-projekt.slnx` — green, 0 warnings, 0 errors
- `dotnet test Tests/Tests.csproj` — **35 / 35 passed**

## Test plan
- [ ] After merge, run `dotnet ef database update --project backend/api/api.csproj`
- [ ] Create a sheet with explicit `Topic = "Algebra"` — response returns "Algebra"
- [ ] Create a sheet with empty `Topic` and assignments tagged `Topic = "Geometry"` — response falls back to "Geometry"
- [ ] `Tags` array round-trips on create / update
- [ ] Open `/edit-assignment-sheet`, pick a sheet, click Hent — form shows title (read-only) + Karakter / Tilbagemelding / Rettenoter only
- [ ] Save → values persist, page redirects to `/assignment-sheet-overview`