### PR TITLE
fix(api+blazor): unbreak login — duplicate Program.cs registrations + SPA port mismatch

### DIFF
--- a/backend/api/Program.cs
+++ b/backend/api/Program.cs
@@ -88,64 +88,6 @@ builder.Services.AddScoped<IStudentService, StudentService>();
 builder.Services.AddSingleton<MongoImageService>();
 builder.Services.AddSingleton<MongoVideoService>();
 
-builder.Services.AddDbContext<ApplicationDbContext> (options =>
-    options.UseSqlServer (builder.Configuration.GetConnectionString ("DefaultConnection")));
-
-builder.Services.AddIdentity<ApplicationUser, IdentityRole> (options =>
-{
-    options.Password.RequireDigit = false;
-    options.Password.RequiredLength = 6;
-})
-.AddEntityFrameworkStores<ApplicationDbContext> ()
-.AddDefaultTokenProviders ();
-
-if (string.IsNullOrWhiteSpace (jwtKey) || jwtKey.Length < 32)
-{
-    throw new InvalidOperationException ("JWT key is missing or too short (min 32 chars).");
-}
-
-builder.Services.AddAuthentication (options =>
-{
-    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
-})
-.AddJwtBearer (options =>
-{
-    options.TokenValidationParameters = new TokenValidationParameters
-    {
-        ValidateIssuerSigningKey = true,
-        IssuerSigningKey = key,
-        ValidateIssuer = false,
-        ValidateAudience = false,
-        RoleClaimType = ClaimTypes.Role
-    };
-});
-
-builder.Services.AddCors (options =>
-{
-    options.AddPolicy("DevCors", policy =>
-    {
-        policy.WithOrigins("https://localhost:5001") // frontend URL
-              .AllowAnyHeader()
-              .AllowAnyMethod()
-              .AllowCredentials();
-    });
-});
-
-builder.Services.AddScoped<ITokenService, TokenService> ();
-
-// Only required for when seeding below
-//builder.Services.AddScoped<DbSeeder> ();
-
-//hvorfor?
-//builder.Services.AddRazorPages ();
-builder.Services.AddServerSideBlazor ();
-
-builder.Services.AddControllers ();
-builder.Services.AddScoped<AssignmentService>();
-builder.Services.AddScoped<IStudentService, StudentService> ();
-builder.Services.AddSingleton<MongoAttachmentService>();
-
 var app = builder.Build();
 
 if (builder.Configuration.GetValue("SeedDatabase", false))

--- a/blazor/blazor/wwwroot/appsettings.json
+++ b/blazor/blazor/wwwroot/appsettings.json
@@ -1,3 +1,3 @@
 {
-  "ApiBaseUrl": "https://localhost:5001"
+  "ApiBaseUrl": "http://localhost:5000"
 }


### PR DESCRIPTION
## TL;DR
Two commits, two real fixes. The login "fetch error" had two root causes; fixing only one wasn't enough.

## Root causes

### (a) backend/api/Program.cs — duplicate registration block (commit 3e54504)
Lines 91–147 were a copy of the earlier registrations (DbContext, Identity, Auth, JwtBearer, Cors, Controllers, ServerSideBlazor + two unused services). The duplicate `AddIdentity` call crashed the API at startup with:

```
Scheme already exists: Identity.Application
```

So the API container exited on `builder.Build()` and never bound port 5000 — every fetch from the SPA failed at TCP. **This is what was actually breaking login.**

The duplicate block also masked two latent bugs (first-registration-wins): wrong CORS origin (`https://localhost:5001` instead of the Blazor URL), and hardcoded `ValidateIssuer`/`ValidateAudience = false` instead of reading from config. Both fixed implicitly by removing the duplicate.

### (b) blazor/blazor/wwwroot/appsettings.json — wrong API URL (commit cfe852c)
SPA was calling `https://localhost:5001`, but `docker-compose.yml` publishes the API only on `5000:5000` (HTTP). Even with (a) fixed, the SPA still wouldn't reach the API. Switched to `http://localhost:5000`. Works for both `docker compose up` and `./run.sh`.

## Smoke test
- ✅ API container reaches `Now listening on: http://[::]:5000`
- ✅ `curl http://localhost:5000/openapi/v1.json` → 200
- ✅ Without the Program.cs cleanup, the same container fatally exits on `builder.Build()` — confirming root cause (a)
- ❌ End-to-end browser login NOT verified — see follow-up PRs below for the pre-existing issues that block clean-machine setup

## Surfaced while diagnosing — addressed in follow-up PRs
While debugging this, found a few other things broken on Development. Each is a separate PR so they can be reviewed independently:

- **#70** — `docs(readme): make docker compose the canonical run path` — README still pointed at `./run.sh` even though `docker-compose.yml` now starts the full stack including the Blazor SPA.
- **#71** — `fix(compose): authenticate mongo healthcheck (and drop missing-grep dependency)` — mongo's healthcheck was unauthenticated (rejected by mongo's auth) AND piped through `grep` which isn't installed in the slim image. Container stayed "unhealthy" forever, blocking the API via `depends_on`. Fixed both.
- **#72** — `fix(api): drop 5 zombie migrations resurrected by a bad merge (superseded by _InitialCreate)` — five early-March migrations were already replaced by `_InitialCreate` in commit `74e3d5c` but a later bad merge brought them back. They've been silently breaking `dotnet ef database update` on fresh checkouts. Tagged @Greyrib (Mathias) + @Erik for schema review.

(Also noticed `MongoAttachmentService.cs` is dead code after this PR's duplicate-removal — left for a one-line cleanup PR after this lands.)