### PR TITLE
fix(compose): authenticate mongo healthcheck (and drop missing-grep dependency)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       MONGO_INITDB_ROOT_USERNAME: "${MONGO_ROOT_USERNAME}"
       MONGO_INITDB_ROOT_PASSWORD: "${MONGO_ROOT_PASSWORD}"
     healthcheck:
-      test: ["CMD-SHELL", "mongosh --quiet --eval 'db.adminCommand({ping:1}).ok' | grep -q 1"]
+      test: ["CMD-SHELL", "mongosh --quiet --username \"$$MONGO_INITDB_ROOT_USERNAME\" --password \"$$MONGO_INITDB_ROOT_PASSWORD\" --authenticationDatabase admin --eval 'db.adminCommand({ping:1}).ok || quit(1)'"]
       interval: 10s
       timeout: 5s
       retries: 6


### PR DESCRIPTION
## Symptom
On a clean machine, `docker compose up` hangs the API container forever — mongo's healthcheck never returns "healthy", so `depends_on: condition: service_healthy` blocks API startup.

## Two bugs in the existing healthcheck
1. **Auth missing.** Mongo has root auth enabled but the healthcheck command doesn't authenticate, so `db.adminCommand({ping:1})` is rejected.
2. **`grep` not in the slim image.** The original healthcheck piped `mongosh` output through `grep -q 1`, but `mongodb-community-server:7.0-ubi8-slim` doesn't ship `grep`, so every probe was exiting 127 silently.

## Fix
- Pass root credentials into the healthcheck via the same env vars (`MONGO_INITDB_ROOT_USERNAME` / `_PASSWORD`) compose already uses, with the `$$VAR` escaping pattern used elsewhere in the file (e.g. SQL Server's healthcheck).
- Drop the `| grep` step; rely on mongosh's exit code instead: `db.adminCommand({ping:1}).ok || quit(1)`.

## Smoke test
On a fresh volume (`docker compose down -v && docker compose up -d`), the mongo container reaches `Health: healthy` and the API container starts normally instead of hanging on `depends_on`.

Surfaced while diagnosing the login bug — see #69.