### PR TITLE
fix(blazor): restore HTTP ApiBaseUrl for container deploys

### DIFF
--- a/blazor/blazor/wwwroot/appsettings.Development.json
+++ b/blazor/blazor/wwwroot/appsettings.Development.json
@@ -1,0 +1,3 @@
+{
+  "ApiBaseUrl": "https://localhost:5000"
+}

--- a/blazor/blazor/wwwroot/appsettings.json
+++ b/blazor/blazor/wwwroot/appsettings.json
@@ -1,3 +1,3 @@
 {
-  "ApiBaseUrl": "https://localhost:5000"
+  "ApiBaseUrl": "http://localhost:5000"
 }


### PR DESCRIPTION
Fixes the container-mode login regression Bolonel reported on Discord.

**Root cause:** `2f5f2fb` changed `blazor/blazor/wwwroot/appsettings.json` `ApiBaseUrl` from `http://localhost:5000` to `https://localhost:5000`. `docker-compose.yml` runs the API container with `ASPNETCORE_URLS=http://+:5000` and exposes only HTTP on host 5000, so the Wasm client's HTTPS calls hit a non-TLS listener and login fails. Worked from VS-direct because the API's HTTPS launch profile binds 5000 there.

**Fix:** keep `wwwroot/appsettings.json` on `http://localhost:5000` (matches the documented canonical compose run mode from #70), and put the `https://localhost:5000` override into a new `wwwroot/appsettings.Development.json` so VS-direct runs (which set `ASPNETCORE_ENVIRONMENT=Development`) still use HTTPS. Container deploys do not carry that env var into the static Blazor host, so they read the base value.

**Verification gap:** I did not run `docker compose up` end-to-end before pushing — please smoke-test before merging. The change is JSON-only, relying on standard ASP.NET environment-overlay loading.

Refs:
- regression introduced in `2f5f2fb`
- original HTTP setting from #69 (`cfe852c`)
- canonical compose run mode documented in #70