### PR TITLE
fix(tests): extract IMongoImageService/IMongoVideoService so Reqnroll…

### DIFF
--- a/Tests/Services/features/DeleteAssignmentService.feature
+++ b/Tests/Services/features/DeleteAssignmentService.feature
@@ -1,0 +1,16 @@
+Feature: Delete Assignment
+
+  Scenario: Assignment does not exist
+    Given an assignment id
+    And the repository returns null for that id
+    When I delete the assignment
+    Then the result should be false
+
+  Scenario: Assignment exists and is deleted successfully
+    Given an assignment id
+    And the repository returns an assignment for that id
+    And removing the assignment succeeds
+    When I delete the assignment
+    Then the result should be true
+    And images are deleted for the assignment
+    And videos are deleted for the assignment

--- a/Tests/Services/stepdefinitions/DeleteAssignmentServiceStepDefinitions.cs
+++ b/Tests/Services/stepdefinitions/DeleteAssignmentServiceStepDefinitions.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Threading.Tasks;
+using Moq;
+using Reqnroll;
+using FluentAssertions;
+using api.Interfaces;
+using api.Models;
+using api.Services;
+
+namespace Tests.ServiceTests;
+
+[Binding]
+public class DeleteAssignmentServiceSteps
+{
+    private readonly Mock<IAssignmentRepository> _repoMock = new();
+    private readonly Mock<IMongoImageService> _imageServiceMock = new();
+    private readonly Mock<IMongoVideoService> _videoServiceMock = new();
+
+    private AssignmentService _service;
+    private Guid _assignmentId;
+    private bool _result;
+    private Assignment _assignment;
+
+    public DeleteAssignmentServiceSteps()
+    {
+        _service = new AssignmentService(
+            _repoMock.Object,
+            _videoServiceMock.Object,
+            _imageServiceMock.Object
+        );
+    }
+
+    [Given(@"an assignment id")]
+    public void GivenAnAssignmentId()
+    {
+        _assignmentId = Guid.NewGuid();
+    }
+
+    [Given(@"the repository returns null for that id")]
+    public void GivenRepositoryReturnsNull()
+    {
+        _repoMock
+            .Setup(r => r.GetByIdAsync(_assignmentId))
+            .ReturnsAsync((Assignment?)null);
+    }
+
+    [Given(@"the repository returns an assignment for that id")]
+    public void GivenRepositoryReturnsAssignment()
+    {
+        _assignment = new Assignment { Id = _assignmentId };
+
+        _repoMock
+            .Setup(r => r.GetByIdAsync(_assignmentId))
+            .ReturnsAsync(_assignment);
+    }
+
+    [Given(@"removing the assignment succeeds")]
+    public void GivenRemovingSucceeds()
+    {
+        _repoMock
+            .Setup(r => r.RemoveAsync(It.IsAny<Assignment>()))
+            .ReturnsAsync(true);
+    }
+
+    [When(@"I delete the assignment")]
+    public async Task WhenIDeleteTheAssignment()
+    {
+        _result = await _service.DeleteAssignment(_assignmentId);
+    }
+
+    [Then(@"the result should be false")]
+    public void ThenResultShouldBeFalse()
+    {
+        _result.Should().BeFalse();
+
+        _imageServiceMock.Verify(
+            s => s.DeleteImagesByAssignmentIdAsync(It.IsAny<string>()),
+            Times.Never
+        );
+
+        _videoServiceMock.Verify(
+            s => s.DeleteVideosByAssignmentIdAsync(It.IsAny<string>()),
+            Times.Never
+        );
+    }
+
+    [Then(@"the result should be true")]
+    public void ThenResultShouldBeTrue()
+    {
+        _result.Should().BeTrue();
+    }
+
+    [Then(@"images are deleted for the assignment")]
+    public void ThenImagesAreDeleted()
+    {
+        _imageServiceMock.Verify(
+            s => s.DeleteImagesByAssignmentIdAsync(_assignmentId.ToString()),
+            Times.Once
+        );
+    }
+
+    [Then(@"videos are deleted for the assignment")]
+    public void ThenVideosAreDeleted()
+    {
+        _videoServiceMock.Verify(
+            s => s.DeleteVideosByAssignmentIdAsync(_assignmentId.ToString()),
+            Times.Once
+        );
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -13,6 +13,9 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Reqnroll" Version="3.3.4" />
+    <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.4" />
+    <PackageReference Include="Reqnroll.xUnit" Version="3.3.4" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>

--- a/backend/api/Interfaces/IMongoImageService.cs
+++ b/backend/api/Interfaces/IMongoImageService.cs
@@ -1,0 +1,14 @@
+using MongoDB.Bson;
+using MongoDB.Driver.GridFS;
+
+namespace api.Interfaces;
+
+public interface IMongoImageService
+{
+    Task<ObjectId> UploadImageAsync(byte[] fileBytes, string fileName, string assignmentId, string contentType = "image/jpeg");
+    Task<byte[]> DownloadImageAsync(ObjectId fileId);
+    Task<GridFSFileInfo> GetFileInfoAsync(ObjectId fileId);
+    Task<List<string>> GetImagesByAssignmentIdAsync(string assignmentId);
+    Task<List<string>> GetAllImagesAsync();
+    Task DeleteImagesByAssignmentIdAsync(string assignmentId);
+}

--- a/backend/api/Interfaces/IMongoVideoService.cs
+++ b/backend/api/Interfaces/IMongoVideoService.cs
@@ -1,0 +1,14 @@
+using MongoDB.Bson;
+using MongoDB.Driver.GridFS;
+
+namespace api.Interfaces;
+
+public interface IMongoVideoService
+{
+    Task<ObjectId> UploadVideoAsync(byte[] fileBytes, string fileName, List<string> assignmentIds, string contentType = "video/mp4");
+    Task<byte[]> DownloadVideoAsync(ObjectId fileId);
+    Task<GridFSFileInfo> GetFileInfoAsync(ObjectId fileId);
+    Task<List<string>> GetVideosByAssignmentIdAsync(string assignmentId);
+    Task<List<string>> GetAllVideosAsync();
+    Task DeleteVideosByAssignmentIdAsync(string assignmentId);
+}

--- a/backend/api/Program.cs
+++ b/backend/api/Program.cs
@@ -87,7 +87,9 @@ builder.Services.AddSingleton<IAssignmentSheetPdfService, AssignmentSheetPdfServ
 builder.Services.AddScoped<IStudentRepository, StudentRepository>();
 builder.Services.AddScoped<IStudentService, StudentService>();
 builder.Services.AddSingleton<MongoImageService>();
+builder.Services.AddSingleton<IMongoImageService>(sp => sp.GetRequiredService<MongoImageService>());
 builder.Services.AddSingleton<MongoVideoService>();
+builder.Services.AddSingleton<IMongoVideoService>(sp => sp.GetRequiredService<MongoVideoService>());
 
 var app = builder.Build();
 

--- a/backend/api/Services/AssignmentService.cs
+++ b/backend/api/Services/AssignmentService.cs
@@ -10,13 +10,13 @@ namespace api.Services;
 public class AssignmentService : IAssignmentService
 {
     private readonly IAssignmentRepository _repo;
-    private readonly MongoImageService _mongoImageService;
-    private readonly MongoVideoService _mongoVideoService;
+    private readonly IMongoImageService _mongoImageService;
+    private readonly IMongoVideoService _mongoVideoService;
 
     public AssignmentService(
         IAssignmentRepository repo,
-        MongoVideoService mongoVideoService,
-        MongoImageService mongoImageService)
+        IMongoVideoService mongoVideoService,
+        IMongoImageService mongoImageService)
     {
         _repo = repo;
         _mongoImageService = mongoImageService;

--- a/backend/api/Services/MongoImageService.cs
+++ b/backend/api/Services/MongoImageService.cs
@@ -1,10 +1,11 @@
+using api.Interfaces;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.Driver.GridFS;
 
 namespace api.Services;
 
-public class MongoImageService{
+public class MongoImageService : IMongoImageService {
     private readonly IMongoDatabase _database;
     private readonly GridFSBucket _gridFS;
     private readonly string _apiBaseUrl;

--- a/backend/api/Services/MongoVideoService.cs
+++ b/backend/api/Services/MongoVideoService.cs
@@ -1,10 +1,11 @@
+using api.Interfaces;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.Driver.GridFS;
 
 namespace api.Services;
 
-public class MongoVideoService{
+public class MongoVideoService : IMongoVideoService {
     private readonly IMongoDatabase _database;
     private readonly GridFSBucket _gridFS;
     private readonly string _apiBaseUrl;


### PR DESCRIPTION
… delete-assignment specs can mock them

Re-applies Erik's Reqnroll Delete Assignment specs (from PR #80) on top of examFinal, which had diverged via PR #60 (interfaces moved to api.Interfaces) and the removal of the IMongo* interface types the original test depended on.

Source changes:
- Add api.Interfaces.IMongoImageService / IMongoVideoService.
- MongoImageService / MongoVideoService implement them. Behavior unchanged.
- AssignmentService depends on the interfaces instead of the concrete classes, enabling Moq-based verification of DeleteImages/VideosByAssignmentIdAsync.
- Program.cs: register the interface mappings alongside the existing concrete singletons so other callers (controllers) keep resolving the concrete types.

Test changes (vs. PR #80):
- using api.Interfaces; (was api.Data; the type moved).
- Constructor args reordered to match examFinal's (repo, video, image) signature.
- Cast null → (Assignment?)null for the nullable-enabled Tests project.
- Tests.csproj: add Reqnroll / Reqnroll.xUnit / Reqnroll.Tools.MsBuild.Generation package refs that examFinal lacks but the BDD specs require.

Note: local build not verified — nuget.config in this worktree requires Azure Artifacts auth I do not have. CI on the PR will be the real check.